### PR TITLE
Add tests using Clojure Specs and Integration tests

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,2 +1,4 @@
 {:paths ["src"]
- :deps {org.clojure/clojure {:mvn/version "1.12.0"}}}
+ :deps {org.clojure/clojure {:mvn/version "1.12.0"}}
+ :aliases {:test {:extra-paths ["test"]
+                  :extra-deps {org.clojure/test.check {:mvn/version "1.1.1"}}}}}

--- a/src/datachannel/core.clj
+++ b/src/datachannel/core.clj
@@ -97,8 +97,10 @@
         #_(println "Ignored chunk type:" (:type chunk))))))
 
 
-(defn- run-loop [channel selector ssl-engine peer-addr connection]
+(defn- run-loop [channel selector ssl-engine peer-addr connection & [initial-data]]
   (let [net-in (make-buffer)
+        _ (when (and initial-data (.hasRemaining initial-data))
+            (.put net-in initial-data))
         net-out (make-buffer)
         app-in (make-buffer)  ;; Decrypted DTLS (Incoming SCTP)
         app-out (make-buffer) ;; To be Encrypted DTLS (Outgoing SCTP)
@@ -300,7 +302,7 @@
                           (when (.hasRemaining app-in)
                              (println "Got data on first packet?"))))
 
-                    (run-loop channel selector engine peer-addr connection))
+                    (run-loop channel selector engine peer-addr connection temp-buf))
                   (catch Exception e
                     (println "Server Loop Error:" e)))))]
       (.start t))

--- a/src/datachannel/sctp.clj
+++ b/src/datachannel/sctp.clj
@@ -114,8 +114,8 @@
           v-bytes (if (bytes? v) v (byte-array 0))
           len (+ 4 (alength v-bytes))
           padding (pad len)]
-      (.putShort buf type-code)
-      (.putShort buf len)
+      (.putShort buf (unchecked-short type-code))
+      (.putShort buf (unchecked-short len))
       (.put buf v-bytes)
       (dotimes [_ padding] (.put buf (byte 0))))))
 
@@ -217,6 +217,15 @@
                  (.position buf (+ chunk-start val-len))
                  chunk-data)
 
+              :cookie-ack
+              chunk-data
+
+              :shutdown
+              chunk-data
+
+              :shutdown-ack
+              chunk-data
+
               ;; Default: just consume the body bytes
               (let [body (byte-array val-len)]
                 (.get buf body)
@@ -258,28 +267,28 @@
     (case type-key
       :data
       (do
-        (.putInt buf (int (:tsn chunk)))
-        (.putShort buf (short (:stream-id chunk)))
-        (.putShort buf (short (:seq-num chunk)))
-        (.putInt buf (int (get protocols (:protocol chunk) (:protocol chunk))))
+        (.putInt buf (unchecked-int (:tsn chunk)))
+        (.putShort buf (unchecked-short (:stream-id chunk)))
+        (.putShort buf (unchecked-short (:seq-num chunk)))
+        (.putInt buf (unchecked-int (get protocols (:protocol chunk) (:protocol chunk))))
         (.put buf ^bytes (:payload chunk)))
 
       :init
       (do
-        (.putInt buf (int (:init-tag chunk)))
-        (.putInt buf (int (:a-rwnd chunk)))
-        (.putShort buf (short (:outbound-streams chunk)))
-        (.putShort buf (short (:inbound-streams chunk)))
-        (.putInt buf (int (:initial-tsn chunk)))
+        (.putInt buf (unchecked-int (:init-tag chunk)))
+        (.putInt buf (unchecked-int (:a-rwnd chunk)))
+        (.putShort buf (unchecked-short (:outbound-streams chunk)))
+        (.putShort buf (unchecked-short (:inbound-streams chunk)))
+        (.putInt buf (unchecked-int (:initial-tsn chunk)))
         (encode-params buf (:params chunk)))
 
       :init-ack
       (do
-        (.putInt buf (int (:init-tag chunk)))
-        (.putInt buf (int (:a-rwnd chunk)))
-        (.putShort buf (short (:outbound-streams chunk)))
-        (.putShort buf (short (:inbound-streams chunk)))
-        (.putInt buf (int (:initial-tsn chunk)))
+        (.putInt buf (unchecked-int (:init-tag chunk)))
+        (.putInt buf (unchecked-int (:a-rwnd chunk)))
+        (.putShort buf (unchecked-short (:outbound-streams chunk)))
+        (.putShort buf (unchecked-short (:inbound-streams chunk)))
+        (.putInt buf (unchecked-int (:initial-tsn chunk)))
         (encode-params buf (:params chunk)))
 
       :cookie-echo
@@ -287,15 +296,15 @@
 
       :sack
       (do
-        (.putInt buf (int (:cum-tsn-ack chunk)))
-        (.putInt buf (int (:a-rwnd chunk)))
-        (.putShort buf (short (count (:gap-blocks chunk))))
-        (.putShort buf (short (count (:duplicate-tsns chunk))))
+        (.putInt buf (unchecked-int (:cum-tsn-ack chunk)))
+        (.putInt buf (unchecked-int (:a-rwnd chunk)))
+        (.putShort buf (unchecked-short (count (:gap-blocks chunk))))
+        (.putShort buf (unchecked-short (count (:duplicate-tsns chunk))))
         (doseq [[start end] (:gap-blocks chunk)]
-          (.putShort buf (short start))
-          (.putShort buf (short end)))
+          (.putShort buf (unchecked-short start))
+          (.putShort buf (unchecked-short end)))
         (doseq [dup (:duplicate-tsns chunk)]
-          (.putInt buf (int dup))))
+          (.putInt buf (unchecked-int dup))))
 
       :heartbeat
       (encode-params buf (:params chunk))
@@ -310,7 +319,7 @@
     (let [end-pos (.position buf)
           len (- end-pos start-pos)
           padding (pad len)]
-      (.putShort buf (+ start-pos 2) (short len))
+      (.putShort buf (+ start-pos 2) (unchecked-short len))
       (dotimes [_ padding] (.put buf (byte 0))))))
 
 (defn update-checksum [^ByteBuffer buf]
@@ -327,9 +336,9 @@
       buf)))
 
 (defn encode-packet [packet ^ByteBuffer buf]
-  (.putShort buf (short (:src-port packet)))
-  (.putShort buf (short (:dst-port packet)))
-  (.putInt buf (int (:verification-tag packet)))
+  (.putShort buf (unchecked-short (:src-port packet)))
+  (.putShort buf (unchecked-short (:dst-port packet)))
+  (.putInt buf (unchecked-int (:verification-tag packet)))
   (.putInt buf 0) ;; Checksum placeholder
   (doseq [chunk (:chunks packet)]
     (encode-chunk buf chunk))

--- a/test/datachannel/dtls_test.clj
+++ b/test/datachannel/dtls_test.clj
@@ -1,0 +1,27 @@
+(ns datachannel.dtls-test
+  (:require [clojure.test :refer :all]
+            [datachannel.dtls :as dtls])
+  (:import [javax.net.ssl SSLContext SSLEngine]))
+
+(deftest test-fingerprint
+  (testing "Fingerprint generation"
+    (let [cert-data (dtls/generate-cert)]
+      (is (map? cert-data))
+      (is (some? (:cert cert-data)))
+      (is (some? (:key cert-data)))
+      (is (string? (:fingerprint cert-data)))
+      (is (re-matches #"[0-9A-F]{2}(:[0-9A-F]{2})+" (:fingerprint cert-data))))))
+
+(deftest test-ssl-context
+  (testing "SSL Context creation"
+    (let [cert-data (dtls/generate-cert)
+          ctx (dtls/create-ssl-context (:cert cert-data) (:key cert-data))]
+      (is (instance? SSLContext ctx)))))
+
+(deftest test-engine-creation
+  (testing "SSLEngine creation"
+    (let [cert-data (dtls/generate-cert)
+          ctx (dtls/create-ssl-context (:cert cert-data) (:key cert-data))
+          engine (dtls/create-engine ctx true)]
+      (is (instance? SSLEngine engine))
+      (is (.getUseClientMode engine)))))

--- a/test/datachannel/integration_test.clj
+++ b/test/datachannel/integration_test.clj
@@ -1,0 +1,41 @@
+(ns datachannel.integration-test
+  (:require [clojure.test :refer :all]
+            [datachannel.core :as dc]))
+
+(deftest test-echo-integration
+  (let [port (+ 15000 (rand-int 1000)) ;; Randomize port slightly
+        server-received (promise)
+        client-received (promise)
+        client-connected (promise)
+
+        ;; Start server
+        server (dc/listen port)
+        ;; Start client
+        client (dc/connect "127.0.0.1" port)]
+
+    (reset! (:on-message server)
+            (fn [msg]
+              (let [s (String. msg "UTF-8")]
+                (deliver server-received s)
+                (dc/send-msg server "World"))))
+
+    (reset! (:on-message client)
+            (fn [msg]
+              (let [s (String. msg "UTF-8")]
+                (deliver client-received s))))
+
+    (reset! (:on-open client)
+            (fn []
+              (deliver client-connected true)
+              (dc/send-msg client "Hello")))
+
+    (try
+      ;; Wait for connection
+      (is (deref client-connected 10000 false) "Client failed to connect")
+
+      ;; Wait for messages
+      (is (= "Hello" (deref server-received 10000 :timeout)))
+      (is (= "World" (deref client-received 10000 :timeout)))
+
+      (catch Exception e
+        (is false (str "Exception during integration test: " (.getMessage e)))))))

--- a/test/datachannel/sctp_test.clj
+++ b/test/datachannel/sctp_test.clj
@@ -1,0 +1,193 @@
+(ns datachannel.sctp-test
+  (:require [clojure.test :refer :all]
+            [clojure.spec.alpha :as s]
+            [clojure.spec.gen.alpha :as gen]
+            [clojure.test.check :as tc]
+            [clojure.test.check.generators :as tc-gen]
+            [clojure.test.check.properties :as prop]
+            [clojure.test.check.clojure-test :refer [defspec]]
+            [datachannel.sctp :as sctp])
+  (:import [java.nio ByteBuffer]))
+
+;; Helper to compare byte arrays
+(defn bytes= [b1 b2]
+  (if (and (nil? b1) (nil? b2))
+    true
+    (if (or (nil? b1) (nil? b2))
+      false
+      (java.util.Arrays/equals ^bytes b1 ^bytes b2))))
+
+;; Specs
+
+(s/def ::src-port (s/int-in 0 65536))
+(s/def ::dst-port (s/int-in 0 65536))
+(s/def ::verification-tag int?)
+(s/def ::checksum int?)
+
+(s/def ::init-tag int?)
+(s/def ::a-rwnd int?)
+(s/def ::outbound-streams (s/int-in 0 65536))
+(s/def ::inbound-streams (s/int-in 0 65536))
+(s/def ::initial-tsn int?)
+(s/def ::params map?)
+
+(s/def ::cookie bytes?)
+
+(s/def ::tsn int?)
+(s/def ::stream-id (s/int-in 0 65536))
+(s/def ::seq-num (s/int-in 0 65536))
+(s/def ::protocol #{:webrtc/dcep :webrtc/string :webrtc/binary :webrtc/empty-string :webrtc/empty-binary 50 51 53 56 57})
+(s/def ::payload bytes?)
+(s/def ::unordered boolean?)
+(s/def ::beginning boolean?)
+(s/def ::ending boolean?)
+
+(s/def ::cum-tsn-ack int?)
+(s/def ::gap-blocks (s/coll-of (s/tuple (s/int-in 0 65536) (s/int-in 0 65536))))
+(s/def ::duplicate-tsns (s/coll-of int?))
+
+(defmulti chunk-type :type)
+
+(defmethod chunk-type :init [_]
+  (s/keys :req-un [::init-tag ::a-rwnd ::outbound-streams ::inbound-streams ::initial-tsn ::params]))
+
+(defmethod chunk-type :init-ack [_]
+  (s/keys :req-un [::init-tag ::a-rwnd ::outbound-streams ::inbound-streams ::initial-tsn ::params]))
+
+(defmethod chunk-type :cookie-echo [_]
+  (s/keys :req-un [::cookie]))
+
+(defmethod chunk-type :cookie-ack [_]
+  (s/keys :req [:datachannel.sctp/type]))
+
+(defmethod chunk-type :data [_]
+  (s/keys :req-un [::tsn ::stream-id ::seq-num ::protocol ::payload]
+          :opt-un [::unordered ::beginning ::ending]))
+
+(defmethod chunk-type :sack [_]
+  (s/keys :req-un [::cum-tsn-ack ::a-rwnd ::gap-blocks ::duplicate-tsns]))
+
+(defmethod chunk-type :heartbeat [_]
+  (s/keys :req-un [::params]))
+
+(defmethod chunk-type :heartbeat-ack [_]
+  (s/keys :req-un [::params]))
+
+(defmethod chunk-type :default [_]
+  map?)
+
+(s/def ::chunk (s/multi-spec chunk-type :type))
+
+(s/def ::chunks (s/coll-of ::chunk))
+
+(s/def ::packet (s/keys :req-un [::src-port ::dst-port ::verification-tag ::chunks]
+                        :opt-un [::checksum]))
+
+;; Generators
+
+(def byte-array-gen (tc-gen/fmap byte-array (tc-gen/vector (tc-gen/fmap byte (tc-gen/choose -128 127)))))
+
+(defn data-flags [{:keys [unordered beginning ending]}]
+  (bit-or (if unordered 4 0)
+          (if beginning 2 0)
+          (if ending 1 0)))
+
+(def uint32-gen (tc-gen/large-integer* {:min 0 :max 4294967295}))
+
+(def chunk-gen
+  (tc-gen/one-of
+   [(tc-gen/hash-map :type (tc-gen/return :init)
+                  :init-tag uint32-gen
+                  :a-rwnd uint32-gen
+                  :outbound-streams (tc-gen/choose 0 65535)
+                  :inbound-streams (tc-gen/choose 0 65535)
+                  :initial-tsn uint32-gen
+                  :params (tc-gen/return {}))
+    (tc-gen/hash-map :type (tc-gen/return :init-ack)
+                  :init-tag uint32-gen
+                  :a-rwnd uint32-gen
+                  :outbound-streams (tc-gen/choose 0 65535)
+                  :inbound-streams (tc-gen/choose 0 65535)
+                  :initial-tsn uint32-gen
+                  :params (tc-gen/return {}))
+    (tc-gen/hash-map :type (tc-gen/return :cookie-echo)
+                  :cookie byte-array-gen)
+    (tc-gen/hash-map :type (tc-gen/return :cookie-ack))
+    (tc-gen/fmap (fn [data] (assoc data :flags (data-flags data)))
+              (tc-gen/hash-map :type (tc-gen/return :data)
+                            :tsn uint32-gen
+                            :stream-id (tc-gen/choose 0 65535)
+                            :seq-num (tc-gen/choose 0 65535)
+                            :protocol (tc-gen/elements [:webrtc/string :webrtc/binary])
+                            :payload byte-array-gen
+                            :unordered tc-gen/boolean
+                            :beginning tc-gen/boolean
+                            :ending tc-gen/boolean))
+    (tc-gen/hash-map :type (tc-gen/return :sack)
+                  :cum-tsn-ack uint32-gen
+                  :a-rwnd uint32-gen
+                  :gap-blocks (tc-gen/vector (tc-gen/tuple (tc-gen/choose 0 65535) (tc-gen/choose 0 65535)))
+                  :duplicate-tsns (tc-gen/vector uint32-gen))
+    (tc-gen/hash-map :type (tc-gen/return :heartbeat)
+                  :params (tc-gen/return {}))
+    (tc-gen/hash-map :type (tc-gen/return :heartbeat-ack)
+                  :params (tc-gen/return {}))]))
+
+(def packet-gen
+  (tc-gen/hash-map :src-port (tc-gen/choose 0 65535)
+                :dst-port (tc-gen/choose 0 65535)
+                :verification-tag uint32-gen
+                :chunks (tc-gen/vector chunk-gen)))
+
+;; Tests
+
+(defn round-trip [packet]
+  (let [buf (ByteBuffer/allocate 65536)
+        _ (sctp/encode-packet packet buf)
+        _ (.flip buf)]
+    (sctp/decode-packet buf)))
+
+;; Deep compare function that handles byte arrays and specific fields
+(defn packet= [p1 p2]
+  (and (= (dissoc p1 :chunks :checksum) (dissoc p2 :chunks :checksum))
+       (= (count (:chunks p1)) (count (:chunks p2)))
+       (every? true?
+               (map (fn [c1 c2]
+                      (and (= (:type c1) (:type c2))
+                           (case (:type c1)
+                             :data (and (= (dissoc c1 :payload :flags :length) (dissoc c2 :payload :flags :length))
+                                        (bytes= (:payload c1) (:payload c2)))
+                             :cookie-echo (bytes= (:cookie c1) (:cookie c2))
+                             ;; For other types, we ignore flags and length as they are transport artifacts
+                             (= (dissoc c1 :flags :length) (dissoc c2 :flags :length)))))
+                    (:chunks p1)
+                    (:chunks p2)))))
+
+(defspec packet-encoding-decoding-test 100
+  (prop/for-all [packet packet-gen]
+    (let [decoded (round-trip packet)]
+      (packet= packet decoded))))
+
+(deftest manual-data-chunk-test
+  (let [data-chunk {:type :data
+                    :tsn 12345
+                    :stream-id 1
+                    :seq-num 10
+                    :protocol :webrtc/string
+                    :payload (.getBytes "Hello" "UTF-8")
+                    :unordered false
+                    :beginning true
+                    :ending true
+                    :flags 3}
+        packet {:src-port 5000
+                :dst-port 5000
+                :verification-tag 999
+                :chunks [data-chunk]}
+        decoded (round-trip packet)
+        decoded-chunk (first (:chunks decoded))]
+
+    (is (= (:tsn data-chunk) (:tsn decoded-chunk)))
+    (is (= "Hello" (String. ^bytes (:payload decoded-chunk) "UTF-8")))
+    (is (true? (:beginning decoded-chunk)))
+    (is (true? (:ending decoded-chunk)))
+    (is (false? (:unordered decoded-chunk)))))

--- a/test/datachannel/test_runner.clj
+++ b/test/datachannel/test_runner.clj
@@ -1,0 +1,13 @@
+(ns datachannel.test-runner
+  (:require [clojure.test :as test]
+            [datachannel.sctp-test]
+            [datachannel.dtls-test]
+            [datachannel.integration-test]))
+
+(defn -main []
+  (let [{:keys [fail error]} (test/run-tests 'datachannel.sctp-test
+                                             'datachannel.dtls-test
+                                             'datachannel.integration-test)]
+    (if (> (+ fail error) 0)
+      (System/exit 1)
+      (System/exit 0))))


### PR DESCRIPTION
This PR adds a comprehensive testing suite to the `datachannel-clj` library. It introduces a `test` directory containing unit tests for DTLS, property-based tests for SCTP using `clojure.spec` and `test.check`, and an integration test for the full data channel connection.

Changes include:
- `deps.edn`: Added `:test` alias.
- `src/datachannel/sctp.clj`: Fixed bugs where 16-bit and 32-bit unsigned fields were being cast to signed Java primitives, causing exceptions for large values. Added support for encoding/decoding chunks without bodies (like `COOKIE_ACK`).
- `src/datachannel/core.clj`: Modified `run-loop` to accept initial data buffer to prevent packet loss during the transition from `listen` to the event loop.
- `test/datachannel/`: Added test files and a test runner.


---
*PR created automatically by Jules for task [200012013442016691](https://jules.google.com/task/200012013442016691) started by @alpeware*