### PR TITLE
Add STUN integration test against Google STUN server

### DIFF
--- a/test/datachannel/stun_integration_test.clj
+++ b/test/datachannel/stun_integration_test.clj
@@ -1,0 +1,35 @@
+(ns datachannel.stun-integration-test
+  (:require [clojure.test :refer :all]
+            [datachannel.stun :as stun])
+  (:import [java.net InetSocketAddress]
+           [java.nio.channels DatagramChannel]
+           [java.nio ByteBuffer]))
+
+(deftest test-google-stun
+  (let [stun-server "stun.l.google.com"
+        stun-port 19302
+        channel (DatagramChannel/open)]
+    (.configureBlocking channel true)
+    (.connect channel (InetSocketAddress. stun-server stun-port))
+
+    (let [req (stun/make-simple-binding-request)]
+      (.write channel req))
+
+    (let [resp-buf (ByteBuffer/allocate 1024)
+          len (.read channel resp-buf)]
+      (.flip resp-buf)
+      (is (> len 0) "Should receive response from STUN server")
+
+      (when (> len 0)
+        (let [parsed (stun/parse-packet resp-buf)]
+          (is (= 0x0101 (:type parsed)) "Should be Binding Success Response")
+
+          (let [xor-addr-attr (get (:attributes parsed) stun/ATTR_XOR_MAPPED_ADDRESS)]
+            (is xor-addr-attr "Should have XOR-MAPPED-ADDRESS attribute")
+            (when xor-addr-attr
+              (let [decoded (stun/decode-xor-mapped-address xor-addr-attr (:cookie parsed))]
+                (is (instance? java.net.InetAddress (:address decoded)))
+                (is (> (:port decoded) 0))
+                (println "Public IP:" (:address decoded) "Port:" (:port decoded))))))))
+
+    (.close channel)))

--- a/test/datachannel/test_runner.clj
+++ b/test/datachannel/test_runner.clj
@@ -2,12 +2,14 @@
   (:require [clojure.test :as test]
             [datachannel.sctp-test]
             [datachannel.dtls-test]
-            [datachannel.integration-test]))
+            [datachannel.integration-test]
+            [datachannel.stun-integration-test]))
 
 (defn -main []
   (let [{:keys [fail error]} (test/run-tests 'datachannel.sctp-test
                                              'datachannel.dtls-test
-                                             'datachannel.integration-test)]
+                                             'datachannel.integration-test
+                                             'datachannel.stun-integration-test)]
     (if (> (+ fail error) 0)
       (System/exit 1)
       (System/exit 0))))


### PR DESCRIPTION
This PR adds a new integration test for `datachannel.stun` which connects to `stun.l.google.com:19302`.
It introduces:
- `stun/make-simple-binding-request`: Creates a simple STUN Binding Request.
- `stun/parse-packet`: Parses a STUN packet into a map.
- `stun/decode-xor-mapped-address`: Decodes the XOR-MAPPED-ADDRESS attribute (IPv4 only).
- `test/datachannel/stun_integration_test.clj`: The integration test.
- Updates `test/datachannel/test_runner.clj` to include the new test.


---
*PR created automatically by Jules for task [12993259547269339682](https://jules.google.com/task/12993259547269339682) started by @alpeware*