### PR TITLE
Add datachannel.integration-test to test runner

### DIFF
--- a/src/datachannel/core.clj
+++ b/src/datachannel/core.clj
@@ -286,3 +286,6 @@
                           :protocol :webrtc/string
                           :payload (.getBytes msg "UTF-8")}]}]
      (.offer (:sctp-out connection) packet)))
+
+(defn close [connection]
+  (close-channel (:channel connection)))

--- a/test/datachannel/integration_test.clj
+++ b/test/datachannel/integration_test.clj
@@ -38,4 +38,7 @@
       (is (= "World" (deref client-received 30000 :timeout)))
 
       (catch Exception e
-        (is false (str "Exception during integration test: " (.getMessage e)))))))
+        (is false (str "Exception during integration test: " (.getMessage e))))
+      (finally
+        (dc/close client)
+        (dc/close server)))))

--- a/test/datachannel/test_runner.clj
+++ b/test/datachannel/test_runner.clj
@@ -11,6 +11,7 @@
   (let [{:keys [fail error]} (test/run-tests 'datachannel.sctp-test
                                              'datachannel.dtls-test
                                              'datachannel.handshake-test
+                                             'datachannel.integration-test
                                              'datachannel.webrtc-java-test
                                              'datachannel.stun-integration-test)]
     (if (> (+ fail error) 0)


### PR DESCRIPTION
This change fixes the blocking `datachannel.integration-test` and adds it to the main test suite. A `close` function has been added to the core API to ensure that client and server connections are properly shut down after the test runs.

Fixes #17

---
*PR created automatically by Jules for task [5400442747620667335](https://jules.google.com/task/5400442747620667335) started by @alpeware*