### PR TITLE
Extend DTLS handshake test coverage

### DIFF
--- a/src/datachannel/dtls.clj
+++ b/src/datachannel/dtls.clj
@@ -88,9 +88,23 @@
         (let [hs-status (.getHandshakeStatus engine)]
           (condp = hs-status
             SSLEngineResult$HandshakeStatus/NOT_HANDSHAKING
-            {:status hs-status
-             :packets (vec packets)
-             :app-data (.toByteArray app-data-out)}
+            (if (.hasRemaining in)
+              (let [temp-app (make-buffer)
+                    res (.unwrap engine in temp-app)]
+                (.flip temp-app)
+                (when (> (.remaining temp-app) 0)
+                  (.write app-data-out (buffer->bytes temp-app) 0 (.remaining temp-app)))
+                (condp = (.getStatus res)
+                  SSLEngineResult$Status/BUFFER_UNDERFLOW
+                  {:status (.getHandshakeStatus engine)
+                   :packets (vec packets)
+                   :app-data (.toByteArray app-data-out)}
+                  SSLEngineResult$Status/CLOSED
+                  (throw (Exception. "SSLEngine closed during handshake"))
+                  (recur (inc loops))))
+              {:status hs-status
+               :packets (vec packets)
+               :app-data (.toByteArray app-data-out)})
 
             SSLEngineResult$HandshakeStatus/FINISHED
             {:status hs-status

--- a/test/datachannel/handshake_test.clj
+++ b/test/datachannel/handshake_test.clj
@@ -4,57 +4,86 @@
   (:import [java.nio ByteBuffer]
            [javax.net.ssl SSLEngine SSLEngineResult$HandshakeStatus]))
 
-(defn- run-handshake [client-engine server-engine]
+(defn- run-handshake-loop [client-engine server-engine]
   (let [client-out (ByteBuffer/allocate 65536)
         server-out (ByteBuffer/allocate 65536)
         client-in (ByteBuffer/allocate 65536)
         server-in (ByteBuffer/allocate 65536)
         max-loops 100]
-
-    ;; Initialize buffers to read mode (empty)
     (.flip client-in)
     (.flip server-in)
-
-    (.beginHandshake client-engine)
-    (.beginHandshake server-engine)
-
     (loop [i 0]
       (if (> i max-loops)
         (throw (Exception. "Handshake failed to complete in max loops"))
         (let [client-status (.getHandshakeStatus client-engine)
               server-status (.getHandshakeStatus server-engine)]
-
-          (if (and (= client-status SSLEngineResult$HandshakeStatus/NOT_HANDSHAKING)
-                   (= server-status SSLEngineResult$HandshakeStatus/NOT_HANDSHAKING))
+          (if (and (or (= client-status SSLEngineResult$HandshakeStatus/NOT_HANDSHAKING)
+                       (= client-status SSLEngineResult$HandshakeStatus/FINISHED))
+                   (or (= server-status SSLEngineResult$HandshakeStatus/NOT_HANDSHAKING)
+                       (= server-status SSLEngineResult$HandshakeStatus/FINISHED))
+                   (not (.hasRemaining client-in))
+                   (not (.hasRemaining server-in)))
             :success
             (do
               ;; Run client step
               (let [res-c (dtls/handshake client-engine client-in client-out)
                     packets-c (:packets res-c)]
-
-                ;; Append output to server input
                 (.compact server-in)
                 (doseq [p packets-c]
                   (.put server-in (ByteBuffer/wrap p)))
                 (.flip server-in))
-
               ;; Run server step
               (let [res-s (dtls/handshake server-engine server-in server-out)
                     packets-s (:packets res-s)]
-
-                ;; Append output to client input
                 (.compact client-in)
                 (doseq [p packets-s]
                   (.put client-in (ByteBuffer/wrap p)))
                 (.flip client-in))
-
               (recur (inc i)))))))))
 
-(deftest test-dtls-handshake
-  (testing "Full DTLS handshake between client and server"
+(defn- exchange-data [client-engine server-engine msg]
+  (let [client-net-out (ByteBuffer/allocate 65536)
+        server-app-out (ByteBuffer/allocate 65536)
+        client-app-in (ByteBuffer/wrap (.getBytes msg))]
+    (let [res-send (dtls/send-app-data client-engine client-app-in client-net-out)
+          res-recv (dtls/receive-app-data server-engine (ByteBuffer/wrap (:bytes res-send)) server-app-out)]
+      (String. (:bytes res-recv)))))
+
+(deftest test-initial-handshake
+  (testing "Initial DTLS handshake between client and server"
     (let [cert-data (dtls/generate-cert)
           ctx (dtls/create-ssl-context (:cert cert-data) (:key cert-data))
           client-engine (dtls/create-engine ctx true)
           server-engine (dtls/create-engine ctx false)]
+      (.beginHandshake client-engine)
+      (.beginHandshake server-engine)
+      (is (= :success (run-handshake-loop client-engine server-engine)))
+      (is (= "Hello World" (exchange-data client-engine server-engine "Hello World"))))))
 
-      (is (= :success (run-handshake client-engine server-engine))))))
+(deftest test-unsolicited-handshake
+  (testing "Handshake where only one side calls beginHandshake explicitly"
+    (let [cert-data (dtls/generate-cert)
+          ctx (dtls/create-ssl-context (:cert cert-data) (:key cert-data))
+          client-engine (dtls/create-engine ctx true)
+          server-engine (dtls/create-engine ctx false)]
+      (.beginHandshake client-engine)
+      ;; server-engine.beginHandshake() is NOT called
+      (is (= :success (run-handshake-loop client-engine server-engine)))
+      (is (= "Hello" (exchange-data client-engine server-engine "Hello"))))))
+
+(deftest test-max-packet-size
+  (testing "Handshake with maximum packet size constraint"
+    (let [cert-data (dtls/generate-cert)
+          ctx (dtls/create-ssl-context (:cert cert-data) (:key cert-data))
+          client-engine (dtls/create-engine ctx true)
+          server-engine (dtls/create-engine ctx false)
+          params (.getSSLParameters client-engine)]
+      ;; Set a small max packet size to force fragmentation
+      (.setMaximumPacketSize params 512)
+      (.setSSLParameters client-engine params)
+      (.setSSLParameters server-engine params)
+
+      (.beginHandshake client-engine)
+      (.beginHandshake server-engine)
+      (is (= :success (run-handshake-loop client-engine server-engine)))
+      (is (= "Hello Frag" (exchange-data client-engine server-engine "Hello Frag"))))))


### PR DESCRIPTION
Extended the DTLS handshake test coverage by adding tests for unsolicited handshakes and maximum packet size constraints, ensuring robust handling of fragmentation and peer-initiated handshakes. Updated the core DTLS implementation to support these scenarios.

Fixes #23

---
*PR created automatically by Jules for task [1848206242740917211](https://jules.google.com/task/1848206242740917211) started by @alpeware*