### PR TITLE
STUN WebRTC integration test and protocol fix

### DIFF
--- a/src/datachannel/stun.clj
+++ b/src/datachannel/stun.clj
@@ -77,10 +77,10 @@
     (put-unsigned-short buf 8)
     (.putLong buf (.nextLong (java.util.Random.)))
 
-    ;; Update Header Length for MI and FINGERPRINT
+    ;; Update Header Length for MI (FINGERPRINT comes after, but length in header for MI should only include MI)
     (let [len-before-mi (- (.position buf) 20)
-          total-len (+ len-before-mi 24 8)]
-       (.putShort buf 2 (unchecked-short total-len)))
+          len-with-mi (+ len-before-mi 24)]
+       (.putShort buf 2 (unchecked-short len-with-mi)))
 
     ;; MESSAGE-INTEGRITY
     (let [len-to-sign (.position buf)
@@ -95,6 +95,11 @@
           (.put buf hmac)))
 
     ;; FINGERPRINT
+    ;; Update Header Length to include FINGERPRINT
+    (let [len-before-fp (- (.position buf) 20)
+          total-len (+ len-before-fp 8)]
+       (.putShort buf 2 (unchecked-short total-len)))
+
     (let [len-to-crc (.position buf)
           data-to-crc (byte-array len-to-crc)]
        (.position buf 0)
@@ -211,11 +216,11 @@
                 (aset xor-addr i (byte (bit-xor (aget addr-bytes i) (aget magic-bytes i)))))
               (.put resp-buf xor-addr))
 
-            ;; Update Header Length to include MI (24) and FINGERPRINT (8)
+            ;; Update Header Length to include MI (24)
             ;; Current Body Length = Pos - 20
             (let [len-before-mi (- (.position resp-buf) 20)
-                  total-len (+ len-before-mi 24 8)]
-               (.putShort resp-buf 2 (unchecked-short total-len)))
+                  len-with-mi (+ len-before-mi 24)]
+               (.putShort resp-buf 2 (unchecked-short len-with-mi)))
 
             ;; Compute HMAC over [0 .. current_pos]
             (let [len-to-sign (.position resp-buf)
@@ -228,6 +233,11 @@
                   (put-unsigned-short resp-buf ATTR_MESSAGE_INTEGRITY)
                   (put-unsigned-short resp-buf 20)
                   (.put resp-buf hmac)))
+
+            ;; Update Header Length to include FINGERPRINT (8)
+            (let [len-before-fp (- (.position resp-buf) 20)
+                  total-len (+ len-before-fp 8)]
+               (.putShort resp-buf 2 (unchecked-short total-len)))
 
             ;; Compute CRC32 over [0 .. current_pos]
             (let [len-to-crc (.position resp-buf)

--- a/test/datachannel/stun_webrtc_integration_test.clj
+++ b/test/datachannel/stun_webrtc_integration_test.clj
@@ -1,0 +1,144 @@
+(ns datachannel.stun-webrtc-integration-test
+  (:require [clojure.test :refer :all]
+            [datachannel.core :as dc]
+            [datachannel.stun :as stun])
+  (:import [dev.onvoid.webrtc PeerConnectionFactory RTCConfiguration PeerConnectionObserver RTCIceServer RTCIceCandidate RTCSessionDescription RTCSdpType]
+           [dev.onvoid.webrtc.media.audio HeadlessAudioDeviceModule]
+           [java.util ArrayList]
+           [java.net InetAddress InetSocketAddress]
+           [java.nio ByteBuffer]))
+
+(defn get-local-ip []
+  (.getHostAddress (InetAddress/getLocalHost)))
+
+(defn extract-ice-credentials [sdp]
+  {:ufrag (second (re-find #"a=ice-ufrag:([^\r\n]+)" sdp))
+   :pwd (second (re-find #"a=ice-pwd:([^\r\n]+)" sdp))})
+
+(defn parse-candidate [candidate-sdp]
+  (let [parts (.split candidate-sdp " ")]
+    {:ip (get parts 4)
+     :port (Integer/parseInt (get parts 5))}))
+
+(defn create-offer [pc]
+  (let [p (promise)]
+    (.createOffer pc (dev.onvoid.webrtc.RTCOfferOptions.)
+                  (reify dev.onvoid.webrtc.CreateSessionDescriptionObserver
+                    (onSuccess [_ description] (deliver p description))
+                    (onFailure [_ error] (deliver p (ex-info "Create offer failed" {:error error})))))
+    @p))
+
+(defn set-local-description [pc description]
+  (let [p (promise)]
+    (.setLocalDescription pc description
+                          (reify dev.onvoid.webrtc.SetSessionDescriptionObserver
+                            (onSuccess [_] (deliver p true))
+                            (onFailure [_ error] (deliver p (ex-info "Set local description failed" {:error error})))))
+    @p))
+
+(defn set-remote-description [pc description]
+  (let [p (promise)]
+    (.setRemoteDescription pc description
+                           (reify dev.onvoid.webrtc.SetSessionDescriptionObserver
+                             (onSuccess [_] (deliver p true))
+                             (onFailure [_ error] (deliver p (ex-info "Set remote description failed" {:error error})))))
+    @p))
+
+(deftest test-stun-integration
+  (println "Starting STUN WebRTC integration test...")
+  (let [adm (HeadlessAudioDeviceModule.)
+        factory (PeerConnectionFactory. adm)
+        config (RTCConfiguration.)
+        ice-servers (ArrayList.)]
+    ;; Use Google STUN server to help initialize ICE agent
+    (let [ice-server (RTCIceServer.)]
+      (set! (.urls ice-server) (doto (ArrayList.) (.add "stun:stun.l.google.com:19302")))
+      (.add ice-servers ice-server))
+    (set! (.iceServers config) ice-servers)
+
+    (let [stun-received-at-clj (atom false)
+          remote-creds (atom nil)
+          local-ip (get-local-ip)
+          port (+ 25000 (rand-int 5000))
+          ice-ufrag "testufrag"
+          ice-pwd "testpwd"
+
+          original-handle-packet stun/handle-packet]
+
+      (with-redefs [stun/handle-packet (fn [buf addr conn]
+                                        (let [pos (.position buf)
+                                              msg-type (bit-and (.getShort buf pos) 0xffff)]
+                                          ;; 0x0001 is Binding Request, 0x0101 is Binding Success Response
+                                          (when (or (= msg-type 0x0001) (= msg-type 0x0101))
+                                            (reset! stun-received-at-clj true))
+                                          (original-handle-packet buf addr conn)))]
+
+        (let [server (dc/listen port :host local-ip :ice-ufrag ice-ufrag :ice-pwd ice-pwd)
+              server-cert-fingerprint (:fingerprint (:cert-data server))
+
+              observer (reify PeerConnectionObserver
+                         (onIceCandidate [_ candidate]
+                           (when-let [creds @remote-creds]
+                             (try
+                               (let [cand-info (parse-candidate (.sdp candidate))
+                                     req (stun/make-binding-request ice-ufrag (:ufrag creds) (:pwd creds))
+                                     addr (InetSocketAddress. ^String (:ip cand-info) (int (:port cand-info)))]
+                                 (when (or (.isLoopbackAddress (.getAddress addr)) (.isSiteLocalAddress (.getAddress addr)))
+                                   (.send (:channel server) req addr)))
+                               (catch Exception e))))
+                         (onIceConnectionChange [_ state])
+                         (onConnectionChange [_ state])
+                         (onSignalingChange [_ state])
+                         (onIceGatheringChange [_ state])
+                         (onIceCandidatesRemoved [_ candidates])
+                         (onAddStream [_ stream])
+                         (onRemoveStream [_ stream])
+                         (onDataChannel [_ channel])
+                         (onRenegotiationNeeded [_])
+                         (onAddTrack [_ receiver streams])
+                         (onTrack [_ transceiver])
+                         (onIceCandidateError [_ event]))
+
+              pc (.createPeerConnection factory config observer)
+              dc-init (dev.onvoid.webrtc.RTCDataChannelInit.)
+              _ (.createDataChannel pc "test" dc-init)]
+
+          (try
+            (let [offer (create-offer pc)]
+              (reset! remote-creds (extract-ice-credentials (.sdp offer)))
+              (set-local-description pc offer)
+
+              (let [sdp-str (str "v=0\r\n"
+                                 "o=- 123456789 2 IN IP4 " local-ip "\r\n"
+                                 "s=-\r\n"
+                                 "t=0 0\r\n"
+                                 "a=group:BUNDLE 0\r\n"
+                                 "m=application " port " UDP/DTLS/SCTP webrtc-datachannel\r\n"
+                                 "c=IN IP4 " local-ip "\r\n"
+                                 "a=setup:passive\r\n"
+                                 "a=mid:0\r\n"
+                                 "a=sctp-port:5000\r\n"
+                                 "a=fingerprint:sha-256 " server-cert-fingerprint "\r\n"
+                                 "a=ice-ufrag:" ice-ufrag "\r\n"
+                                 "a=ice-pwd:" ice-pwd "\r\n"
+                                 "a=ice-lite\r\n"
+                                 "a=rtcp-mux\r\n")
+                    answer (RTCSessionDescription. RTCSdpType/ANSWER sdp-str)]
+
+                (set-remote-description pc answer)
+
+                (let [candidate-str (str "candidate:1 1 UDP 2130706431 " local-ip " " port " typ host")]
+                  (.addIceCandidate pc (RTCIceCandidate. "0" 0 candidate-str)))
+
+                (println "Waiting for STUN Binding Request from Java...")
+                (is (loop [i 0]
+                      (if (or @stun-received-at-clj (>= i 30))
+                        @stun-received-at-clj
+                        (do (Thread/sleep 1000) (recur (inc i)))))
+                    "Clojure did not receive any STUN Binding Request from Java")))
+
+            (finally
+              (dc/close server)
+              (.close pc)
+              (.dispose factory)
+              (.dispose adm))))))))


### PR DESCRIPTION
Created a new integration test `datachannel.stun-webrtc-integration-test` that verifies STUN packet exchange with `webrtc-java`. 

The test uses `with-redefs` to monitor STUN packet handling in the Clojure library and uses a `webrtc-java` PeerConnection as the remote side.

Additionally, fixed a protocol bug in `src/datachannel/stun.clj` where the STUN header length was incorrectly calculated for MESSAGE-INTEGRITY when a FINGERPRINT was also present. According to RFC 5389, the length field in the STUN header must include the MESSAGE-INTEGRITY attribute during its HMAC computation, but not subsequent attributes like FINGERPRINT. This was causing interoperability issues with strict STUN implementations like `webrtc-java`.

Fixes #25

---
*PR created automatically by Jules for task [17855235559829322009](https://jules.google.com/task/17855235559829322009) started by @alpeware*