### PR TITLE
Add STUN WebRTC integration test to test-runner

### DIFF
--- a/test/datachannel/test_runner.clj
+++ b/test/datachannel/test_runner.clj
@@ -5,7 +5,8 @@
             [datachannel.handshake-test]
             [datachannel.integration-test]
             [datachannel.webrtc-java-test]
-            [datachannel.stun-integration-test]))
+            [datachannel.stun-integration-test]
+            [datachannel.stun-webrtc-integration-test]))
 
 (defn -main []
   (let [{:keys [fail error]} (test/run-tests 'datachannel.sctp-test
@@ -13,7 +14,8 @@
                                              'datachannel.handshake-test
                                              'datachannel.integration-test
                                              'datachannel.webrtc-java-test
-                                             'datachannel.stun-integration-test)]
+                                             'datachannel.stun-integration-test
+                                             'datachannel.stun-webrtc-integration-test)]
     (if (> (+ fail error) 0)
       (System/exit 1)
       (System/exit 0))))


### PR DESCRIPTION
Added `datachannel.stun-webrtc-integration-test` to the automated test runner `test/datachannel/test_runner.clj`. Verified the change by running all tests, which passed successfully.

Fixes #27

---
*PR created automatically by Jules for task [18389060220163020212](https://jules.google.com/task/18389060220163020212) started by @alpeware*