### PR TITLE
Fix WebRTC Data Channel Interoperability

### DIFF
--- a/src/datachannel/core.clj
+++ b/src/datachannel/core.clj
@@ -18,32 +18,66 @@
     (try (.close ch) (catch Exception _))))
 
 (defn- handle-sctp-packet [packet connection]
-  #_(println "Handling SCTP packet:" packet)
   (let [chunks (:chunks packet)
         state (:state connection)]
     (doseq [chunk chunks]
       (case (:type chunk)
         :data
-        (do
-          #_(println "Received DATA chunk")
-          ;; Send SACK? (Not implemented yet, but we should ack eventually)
-          ;; Deliver data
-          (when-let [cb @(:on-message connection)]
-             (cb (:payload chunk))))
+        (let [proto (:protocol chunk)
+              tsn (:tsn chunk)]
+          ;; Update remote TSN and send SACK
+          (swap! state (fn [s]
+                         (if (> tsn (:remote-tsn s))
+                           (assoc s :remote-tsn tsn)
+                           s)))
+          (let [sack-packet {:src-port (:dst-port packet)
+                             :dst-port (:src-port packet)
+                             :verification-tag (:remote-ver-tag @state)
+                             :chunks [{:type :sack
+                                       :cum-tsn-ack (:remote-tsn @state)
+                                       :a-rwnd 100000
+                                       :gap-blocks []
+                                       :duplicate-tsns []}]}]
+             (.offer (:sctp-out connection) sack-packet))
+
+          (cond
+            (= proto :webrtc/dcep)
+            (let [payload (:payload chunk)
+                  msg-type (bit-and (aget ^bytes payload 0) 0xff)]
+              (when (= msg-type 3) ;; OPEN
+                ;; Send DCEP ACK
+                (let [ack-tsn (let [t (:next-tsn @state)]
+                                (swap! state update :next-tsn inc)
+                                t)
+                      ack-ssn (let [s (:ssn @state)]
+                                (swap! state update :ssn inc)
+                                s)
+                      ack-packet {:src-port (:dst-port packet)
+                                  :dst-port (:src-port packet)
+                                  :verification-tag (:remote-ver-tag @state)
+                                  :chunks [{:type :data
+                                            :flags 3 ;; B and E bits
+                                            :tsn ack-tsn
+                                            :stream-id (:stream-id chunk)
+                                            :seq-num ack-ssn
+                                            :protocol :webrtc/dcep
+                                            :payload (byte-array [(byte 2)])}]}]
+                   (.offer (:sctp-out connection) ack-packet))))
+
+            :else
+            (when-let [cb @(:on-message connection)]
+               (cb (:payload chunk)))))
 
         :init
         (do
-          #_(println "Received INIT")
-          ;; Update remote-ver-tag from INIT chunk
-          (swap! state assoc :remote-ver-tag (:init-tag chunk))
-
-          ;; Respond with INIT_ACK
+          (swap! state assoc :remote-ver-tag (:init-tag chunk)
+                             :remote-tsn (dec (:initial-tsn chunk)))
           (let [init-ack {:type :init-ack
                           :init-tag (:local-ver-tag @state)
                           :a-rwnd 100000
                           :outbound-streams (:inbound-streams chunk)
                           :inbound-streams (:outbound-streams chunk)
-                          :initial-tsn (rand-int 2147483647)
+                          :initial-tsn (:next-tsn @state)
                           :params {:cookie (.getBytes (str (System/currentTimeMillis)) "UTF-8")}}
                 packet {:src-port (:dst-port packet)
                         :dst-port (:src-port packet)
@@ -53,11 +87,8 @@
 
         :init-ack
         (do
-          #_(println "Received INIT_ACK")
-          ;; Update remote-ver-tag from INIT_ACK chunk
-          (swap! state assoc :remote-ver-tag (:init-tag chunk))
-
-          ;; Respond with COOKIE_ECHO
+          (swap! state assoc :remote-ver-tag (:init-tag chunk)
+                             :remote-tsn (dec (:initial-tsn chunk)))
           (let [cookie (get-in chunk [:params :cookie])
                 packet {:src-port (:dst-port packet)
                         :dst-port (:src-port packet)
@@ -67,9 +98,6 @@
 
         :cookie-echo
         (do
-           #_(println "Received COOKIE_ECHO")
-           ;; Respond with COOKIE_ACK
-           ;; Use remote-ver-tag for the response packet header
            (let [packet {:src-port (:dst-port packet)
                          :dst-port (:src-port packet)
                          :verification-tag (:remote-ver-tag @state)
@@ -80,22 +108,21 @@
 
         :cookie-ack
         (do
-           #_(println "Received COOKIE_ACK")
            (when-let [cb @(:on-open connection)]
              (cb)))
 
         :heartbeat
         (do
-           #_(println "Received HEARTBEAT")
-           ;; Respond with HEARTBEAT_ACK
            (let [packet {:src-port (:dst-port packet)
                          :dst-port (:src-port packet)
                          :verification-tag (:verification-tag packet)
                          :chunks [{:type :heartbeat-ack :params (:params chunk)}]}]
               (.offer (:sctp-out connection) packet)))
 
-        ;; Ignore others for now
-        #_(println "Ignored chunk type:" (:type chunk))))))
+        :sack nil
+        :heartbeat-ack nil
+        :abort (println "Received SCTP ABORT")
+        nil))))
 
 
 (defn- run-loop [^DatagramChannel channel ^Selector selector ^SSLEngine ssl-engine peer-addr connection & [initial-data]]
@@ -104,8 +131,8 @@
             (.put net-in initial-data)
             (.flip net-in))
         net-out (make-buffer)
-        app-in (make-buffer)  ;; Decrypted DTLS (Incoming SCTP)
-        app-out (make-buffer) ;; To be Encrypted DTLS (Outgoing SCTP)
+        app-in (make-buffer)
+        app-out (make-buffer)
         sctp-out (:sctp-out connection)]
 
     (.register channel selector SelectionKey/OP_READ)
@@ -123,50 +150,56 @@
                 ;; ESTABLISHED
                 (do
                   ;; Incoming
-                  (when (.hasRemaining net-in-loop)
-                    (if (let [b (.get net-in-loop (.position net-in-loop))] (or (= b 0) (= b 1)))
-                      (when-let [resp (stun/handle-packet net-in-loop peer-addr connection)]
-                        (.send channel resp peer-addr))
-                      ;; DTLS App Data
-                      (let [res (dtls/receive-app-data ssl-engine net-in-loop app-in)]
-                        (when-let [bytes (:bytes res)]
-                          (when (> (count bytes) 0)
-                            (try (-> (ByteBuffer/wrap bytes) sctp/decode-packet (handle-sctp-packet connection))
-                                 (catch Exception e (println "SCTP Decode Error:" e))))))))
+                  (while (.hasRemaining net-in-loop)
+                    (let [b (bit-and (.get net-in-loop (.position net-in-loop)) 0xff)]
+                      (cond
+                        (or (= b 0) (= b 1))
+                        (if-let [resp (stun/handle-packet net-in-loop peer-addr connection)]
+                          (.send channel resp peer-addr))
+
+                        (and (>= b 20) (<= b 63))
+                        (let [res (dtls/receive-app-data ssl-engine net-in-loop app-in)]
+                          (when-let [bytes (:bytes res)]
+                            (when (> (count bytes) 0)
+                              (try (-> (ByteBuffer/wrap bytes) sctp/decode-packet (handle-sctp-packet connection))
+                                   (catch Exception e (println "SCTP Decode Error:" e))))))
+
+                        :else
+                        (.position net-in-loop (.limit net-in-loop)))))
 
                   ;; Outgoing
-                  (when-let [packet (.poll sctp-out)]
-                    (.clear app-out)
-                    (sctp/encode-packet packet app-out)
-                    (.flip app-out)
-                    (let [res (dtls/send-app-data ssl-engine app-out net-out)]
-                      (when-let [bytes (:bytes res)]
-                        (when (> (count bytes) 0)
-                          (.send channel (ByteBuffer/wrap bytes) peer-addr))))))
+                  (while (let [packet (.poll sctp-out)]
+                           (when packet
+                             (.clear app-out)
+                             (sctp/encode-packet packet app-out)
+                             (.flip app-out)
+                             (let [res (dtls/send-app-data ssl-engine app-out net-out)]
+                               (when-let [bytes (:bytes res)]
+                                 (when (> (count bytes) 0)
+                                   (.send channel (ByteBuffer/wrap bytes) peer-addr))))
+                             packet))))
 
                 ;; HANDSHAKING
                 (do
-                  ;; Incoming STUN?
                   (if (and (.hasRemaining net-in-loop)
-                           (>= (.remaining net-in-loop) 20)
-                           (let [b (.get net-in-loop (.position net-in-loop))] (or (= b 0) (= b 1))))
+                           (let [b (bit-and (.get net-in-loop (.position net-in-loop)) 0xff)]
+                             (or (= b 0) (= b 1))))
                     (when-let [resp (stun/handle-packet net-in-loop peer-addr connection)]
                       (.send channel resp peer-addr))
 
-                    ;; DTLS Handshake
-                    (let [res (dtls/handshake ssl-engine net-in-loop net-out)]
-                      (doseq [packet (:packets res)]
-                        (.send channel (ByteBuffer/wrap packet) peer-addr))
-                      (when-let [app-data (:app-data res)]
-                        (when (> (count app-data) 0)
-                          (try (-> (ByteBuffer/wrap app-data) sctp/decode-packet (handle-sctp-packet connection))
-                               (catch Exception e (println "SCTP Decode Error (Handshake):" e))))))))))
+                    (when (or (.hasRemaining net-in-loop)
+                              (not= hs-status SSLEngineResult$HandshakeStatus/NEED_UNWRAP))
+                      (let [res (dtls/handshake ssl-engine net-in-loop net-out)]
+                        (doseq [packet (:packets res)]
+                          (.send channel (ByteBuffer/wrap packet) peer-addr))
+                        (when-let [app-data (:app-data res)]
+                          (when (> (count app-data) 0)
+                            (try (-> (ByteBuffer/wrap app-data) sctp/decode-packet (handle-sctp-packet connection))
+                                 (catch Exception e (println "SCTP Decode Error (Handshake):" e)))))))))))
             (catch Exception e
               (println "Error in run-loop processing:" e)))
 
           (.clear net-in-loop)
-
-          ;; Wait for new data
           (let [count (.select selector 10)]
             (if (> count 0)
               (let [keys (.selectedKeys selector)]
@@ -201,7 +234,6 @@
     (.configureBlocking channel false)
     (.connect channel peer-addr)
 
-    ;; Start IO Loop
     (let [t (Thread.
               (fn []
                 (try
@@ -210,7 +242,6 @@
                     (println "Connection Loop Error:" e)))))]
       (.start t))
 
-    ;; Send SCTP INIT
     (let [init-chunk {:type :init
                       :init-tag local-ver-tag
                       :a-rwnd 100000
@@ -229,7 +260,7 @@
 (defn listen [port & {:as options}]
   (let [cert-data (or (:cert-data options) (dtls/generate-cert))
         ctx (dtls/create-ssl-context (:cert cert-data) (:key cert-data))
-        engine (dtls/create-engine ctx false) ;; Server mode
+        engine (dtls/create-engine ctx (boolean (:dtls-client options)))
         channel (DatagramChannel/open)
         selector (Selector/open)
         sctp-out (LinkedBlockingQueue.)
@@ -271,15 +302,17 @@
 (defn send-msg [connection msg]
   (let [state (:state connection)
         ver-tag (:remote-ver-tag @state)
-        tsn (:next-tsn @state)
-        ssn (:ssn @state)
-        _ (swap! state #(-> %
-                            (update :next-tsn inc)
-                            (update :ssn inc)))
+        tsn (let [t (:next-tsn @state)]
+              (swap! state update :next-tsn inc)
+              t)
+        ssn (let [s (:ssn @state)]
+              (swap! state update :ssn inc)
+              s)
         packet {:src-port 5000
                 :dst-port 5000
                 :verification-tag ver-tag
                 :chunks [{:type :data
+                          :flags 3 ;; B and E bits
                           :tsn tsn
                           :stream-id 0
                           :seq-num ssn

--- a/src/datachannel/dtls.clj
+++ b/src/datachannel/dtls.clj
@@ -11,7 +11,7 @@
    [sun.security.x509 X500Name]
    [java.util Date ArrayList]))
 
-(def DEFAULT-PACKET-SIZE 1024)
+(def DEFAULT-PACKET-SIZE 16384)
 
 (defn fingerprint [cert]
   (let [md (MessageDigest/getInstance "SHA-256")]
@@ -118,8 +118,10 @@
 
             SSLEngineResult$HandshakeStatus/NEED_TASK
             (do
-              (when-let [task (.getDelegatedTask engine)]
-                (.run task))
+              (while (let [task (.getDelegatedTask engine)]
+                       (when task
+                         (.run task)
+                         task)))
               (recur (inc loops)))
 
             SSLEngineResult$HandshakeStatus/NEED_WRAP

--- a/src/datachannel/sctp.clj
+++ b/src/datachannel/sctp.clj
@@ -102,8 +102,7 @@
           ;; Skip padding
           (let [padding (pad len)]
              (if (< (.remaining buf) padding)
-               (do ;; Error or incomplete buffer, just skip what we can or return
-                 params)
+               params
                (do
                  (.position buf (+ (.position buf) padding))
                  (recur (assoc params type-key val-bytes))))))))))
@@ -127,7 +126,7 @@
         val-len (- len 4)]
     (cond
       (or (< len 4) (> val-len (.remaining buf)))
-      nil ;; Invalid length
+      nil
 
       :else
       (let [chunk-start (.position buf)
@@ -213,7 +212,6 @@
 
               :abort
               (do
-                 ;; Just skip for now
                  (.position buf (+ chunk-start val-len))
                  chunk-data)
 
@@ -226,12 +224,10 @@
               :shutdown-ack
               chunk-data
 
-              ;; Default: just consume the body bytes
               (let [body (byte-array val-len)]
                 (.get buf body)
                 (merge chunk-data {:body body})))]
 
-        ;; Handle padding
         (let [padding (pad len)]
           (if (<= (+ (.position buf) padding) (.limit buf))
              (.position buf (+ (.position buf) padding))
@@ -239,21 +235,42 @@
 
         parsed-data))))
 
+(defn update-checksum [^ByteBuffer buf]
+  (let [crc (CRC32C.)
+        pos (.position buf)
+        orig-order (.order buf)]
+    (.flip buf)
+    ;; Checksum field is at offset 8.
+    ;; We must use LITTLE_ENDIAN for the checksum itself.
+    (.order buf ByteOrder/BIG_ENDIAN)
+    (.putInt buf 8 0)
+    (.update crc buf)
+    (let [checksum (.getValue crc)]
+      (.order buf ByteOrder/LITTLE_ENDIAN)
+      (.putInt buf 8 (unchecked-int checksum))
+      (.order buf orig-order)
+      (.position buf pos)
+      buf)))
+
 (defn decode-packet [^ByteBuffer buf]
-  (let [src-port (get-unsigned-short buf)
-        dst-port (get-unsigned-short buf)
-        ver-tag (get-unsigned-int buf)
-        checksum (get-unsigned-int buf)]
-    {:src-port src-port
-     :dst-port dst-port
-     :verification-tag ver-tag
-     :checksum checksum
-     :chunks (loop [chunks []]
-               (if (.hasRemaining buf)
-                 (if-let [chunk (decode-chunk buf)]
-                   (recur (conj chunks chunk))
-                   chunks)
-                 chunks))}))
+  (let [orig-order (.order buf)]
+    (.order buf ByteOrder/BIG_ENDIAN)
+    (let [src-port (get-unsigned-short buf)
+          dst-port (get-unsigned-short buf)
+          ver-tag (get-unsigned-int buf)
+          _ (.order buf ByteOrder/LITTLE_ENDIAN)
+          checksum (get-unsigned-int buf)
+          _ (.order buf ByteOrder/BIG_ENDIAN)]
+      {:src-port src-port
+       :dst-port dst-port
+       :verification-tag ver-tag
+       :checksum checksum
+       :chunks (loop [chunks []]
+                 (if (.hasRemaining buf)
+                   (if-let [chunk (decode-chunk buf)]
+                     (recur (conj chunks chunk))
+                     chunks)
+                   chunks))})))
 
 (defn encode-chunk [^ByteBuffer buf chunk]
   (let [start-pos (.position buf)
@@ -262,7 +279,7 @@
         flags (:flags chunk 0)]
     (.put buf (byte type-code))
     (.put buf (byte flags))
-    (.putShort buf 0) ;; Length placeholder
+    (.putShort buf 0)
 
     (case type-key
       :data
@@ -312,7 +329,6 @@
       :heartbeat-ack
       (encode-params buf (:params chunk))
 
-      ;; Default
       (when (:body chunk)
         (.put buf ^bytes (:body chunk))))
 
@@ -322,24 +338,14 @@
       (.putShort buf (+ start-pos 2) (unchecked-short len))
       (dotimes [_ padding] (.put buf (byte 0))))))
 
-(defn update-checksum [^ByteBuffer buf]
-  (let [crc (CRC32C.)
-        pos (.position buf)]
-    (.flip buf)
-    ;; CRC calculation logic:
-    ;; The checksum field is at offset 8 (0-indexed). It is filled with 0s for calculation.
-    (.putInt buf 8 0)
-    (.update crc buf)
-    (let [checksum (.getValue crc)]
-      (.putInt buf 8 (unchecked-int checksum))
-      (.position buf pos)
-      buf)))
-
 (defn encode-packet [packet ^ByteBuffer buf]
-  (.putShort buf (unchecked-short (:src-port packet)))
-  (.putShort buf (unchecked-short (:dst-port packet)))
-  (.putInt buf (unchecked-int (:verification-tag packet)))
-  (.putInt buf 0) ;; Checksum placeholder
-  (doseq [chunk (:chunks packet)]
-    (encode-chunk buf chunk))
-  (update-checksum buf))
+  (let [orig-order (.order buf)]
+    (.order buf ByteOrder/BIG_ENDIAN)
+    (.putShort buf (unchecked-short (:src-port packet)))
+    (.putShort buf (unchecked-short (:dst-port packet)))
+    (.putInt buf (unchecked-int (:verification-tag packet)))
+    (.putInt buf 0)
+    (doseq [chunk (:chunks packet)]
+      (encode-chunk buf chunk))
+    (update-checksum buf)
+    (.order buf orig-order)))

--- a/src/datachannel/stun.clj
+++ b/src/datachannel/stun.clj
@@ -180,83 +180,68 @@
           msg-type (get-unsigned-short buf)
           msg-len (get-unsigned-short buf)
           cookie (.getInt buf)
-          tx-id (byte-array 12)]
-      (.get buf tx-id)
+          tx-id (byte-array 12)
+          _ (.get buf tx-id)]
 
-      ;; Check if it's a Binding Request (0x0001)
-      (when (= msg-type 0x0001)
-        (println "Received STUN Binding Request from" peer-addr)
-        ;; We need ICE password to calculate MESSAGE-INTEGRITY
-        (if-let [password (:ice-pwd connection)]
-          (let [resp-buf (ByteBuffer/allocate 1024) ;; Should be enough
-                _ (.order resp-buf ByteOrder/BIG_ENDIAN)]
+      (let [res (if (= msg-type 0x0001) ;; Binding Request
+                  (if-let [password (:ice-pwd connection)]
+                    (let [resp-buf (ByteBuffer/allocate 1024)
+                          _ (.order resp-buf ByteOrder/BIG_ENDIAN)]
+                      ;; Header
+                      (put-unsigned-short resp-buf 0x0101) ;; Success Response
+                      (put-unsigned-short resp-buf 0)
+                      (.putInt resp-buf magic-cookie)
+                      (.put resp-buf tx-id)
 
-            ;; Header
-            (put-unsigned-short resp-buf 0x0101) ;; Binding Success Response
-            (put-unsigned-short resp-buf 0) ;; Length placeholder
-            (.putInt resp-buf magic-cookie)
-            (.put resp-buf tx-id)
+                      ;; XOR-MAPPED-ADDRESS
+                      (put-unsigned-short resp-buf ATTR_XOR_MAPPED_ADDRESS)
+                      (put-unsigned-short resp-buf 8)
+                      (.put resp-buf (byte 0))
+                      (.put resp-buf (byte 1))
+                      (put-unsigned-short resp-buf (bit-xor (.getPort peer-addr) (bit-shift-right magic-cookie 16)))
+                      (let [addr-bytes (.getAddress (.getAddress peer-addr))
+                            cookie-bytes (ByteBuffer/allocate 4)
+                            _ (.putInt cookie-bytes magic-cookie)
+                            _ (.flip cookie-bytes)
+                            magic-bytes (.array cookie-bytes)
+                            xor-addr (byte-array 4)]
+                        (dotimes [i 4]
+                          (aset xor-addr i (byte (bit-xor (aget addr-bytes i) (aget magic-bytes i)))))
+                        (.put resp-buf xor-addr))
 
-            ;; Attributes
+                      ;; MESSAGE-INTEGRITY
+                      (let [len-before-mi (- (.position resp-buf) 20)
+                            len-with-mi (+ len-before-mi 24)]
+                         (.putShort resp-buf 2 (unchecked-short len-with-mi)))
+                      (let [len-to-sign (.position resp-buf)
+                            data-to-sign (byte-array len-to-sign)]
+                         (.position resp-buf 0)
+                         (.get resp-buf data-to-sign)
+                         (.position resp-buf len-to-sign)
+                         (let [hmac (compute-hmac-sha1 password data-to-sign)]
+                            (put-unsigned-short resp-buf ATTR_MESSAGE_INTEGRITY)
+                            (put-unsigned-short resp-buf 20)
+                            (.put resp-buf hmac)))
 
-            ;; XOR-MAPPED-ADDRESS
-            (put-unsigned-short resp-buf ATTR_XOR_MAPPED_ADDRESS)
-            (put-unsigned-short resp-buf 8) ;; Length
-            (.put resp-buf (byte 0)) ;; Reserved
-            (.put resp-buf (byte 1)) ;; Family IPv4
-            (put-unsigned-short resp-buf (bit-xor (.getPort peer-addr) (bit-shift-right magic-cookie 16)))
+                      ;; FINGERPRINT
+                      (let [len-before-fp (- (.position resp-buf) 20)
+                            total-len (+ len-before-fp 8)]
+                         (.putShort resp-buf 2 (unchecked-short total-len)))
+                      (let [len-to-crc (.position resp-buf)
+                            data-to-crc (byte-array len-to-crc)]
+                         (.position resp-buf 0)
+                         (.get resp-buf data-to-crc)
+                         (.position resp-buf len-to-crc)
+                         (let [crc (compute-crc32 data-to-crc)]
+                            (put-unsigned-short resp-buf ATTR_FINGERPRINT)
+                            (put-unsigned-short resp-buf 4)
+                            (.putInt resp-buf (unchecked-int crc))))
 
-            (let [addr-bytes (.getAddress (.getAddress peer-addr))
-                  cookie-bytes (ByteBuffer/allocate 4)
-                  _ (.putInt cookie-bytes magic-cookie)
-                  _ (.flip cookie-bytes)
-                  magic-bytes (.array cookie-bytes)
-                  xor-addr (byte-array 4)]
-              (dotimes [i 4]
-                (aset xor-addr i (byte (bit-xor (aget addr-bytes i) (aget magic-bytes i)))))
-              (.put resp-buf xor-addr))
-
-            ;; Update Header Length to include MI (24)
-            ;; Current Body Length = Pos - 20
-            (let [len-before-mi (- (.position resp-buf) 20)
-                  len-with-mi (+ len-before-mi 24)]
-               (.putShort resp-buf 2 (unchecked-short len-with-mi)))
-
-            ;; Compute HMAC over [0 .. current_pos]
-            (let [len-to-sign (.position resp-buf)
-                  data-to-sign (byte-array len-to-sign)]
-               (.position resp-buf 0)
-               (.get resp-buf data-to-sign)
-               (.position resp-buf len-to-sign) ;; Restore pos
-
-               (let [hmac (compute-hmac-sha1 password data-to-sign)]
-                  (put-unsigned-short resp-buf ATTR_MESSAGE_INTEGRITY)
-                  (put-unsigned-short resp-buf 20)
-                  (.put resp-buf hmac)))
-
-            ;; Update Header Length to include FINGERPRINT (8)
-            (let [len-before-fp (- (.position resp-buf) 20)
-                  total-len (+ len-before-fp 8)]
-               (.putShort resp-buf 2 (unchecked-short total-len)))
-
-            ;; Compute CRC32 over [0 .. current_pos]
-            (let [len-to-crc (.position resp-buf)
-                  data-to-crc (byte-array len-to-crc)]
-               (.position resp-buf 0)
-               (.get resp-buf data-to-crc)
-               (.position resp-buf len-to-crc) ;; Restore pos
-
-               (let [crc (compute-crc32 data-to-crc)]
-                  (put-unsigned-short resp-buf ATTR_FINGERPRINT)
-                  (put-unsigned-short resp-buf 4)
-                  (.putInt resp-buf (unchecked-int crc))))
-
-            (.flip resp-buf)
-            resp-buf)
-          (do
-            (println "STUN Binding Request received but no ice-pwd configured.")
-            nil))))
-
-    (catch Exception e
-      (println "Error handling STUN packet:" e)
+                      (.flip resp-buf)
+                      resp-buf)
+                    nil)
+                  nil)]
+        (.position buf (min (.limit buf) (+ start-pos 20 msg-len)))
+        res))
+    (catch Exception _
       nil)))

--- a/test/datachannel/test_runner.clj
+++ b/test/datachannel/test_runner.clj
@@ -6,7 +6,8 @@
             [datachannel.integration-test]
             [datachannel.webrtc-java-test]
             [datachannel.stun-integration-test]
-            [datachannel.stun-webrtc-integration-test]))
+            [datachannel.stun-webrtc-integration-test]
+            [datachannel.webrtc-integration-test]))
 
 (defn -main []
   (let [{:keys [fail error]} (test/run-tests 'datachannel.sctp-test
@@ -15,7 +16,8 @@
                                              'datachannel.integration-test
                                              'datachannel.webrtc-java-test
                                              'datachannel.stun-integration-test
-                                             'datachannel.stun-webrtc-integration-test)]
+                                             'datachannel.stun-webrtc-integration-test
+                                             'datachannel.webrtc-integration-test)]
     (if (> (+ fail error) 0)
       (System/exit 1)
       (System/exit 0))))

--- a/test/datachannel/webrtc_integration_test.clj
+++ b/test/datachannel/webrtc_integration_test.clj
@@ -2,7 +2,7 @@
   (:require [clojure.test :refer :all]
             [datachannel.core :as dc]
             [datachannel.stun :as stun])
-  (:import [dev.onvoid.webrtc PeerConnectionFactory RTCConfiguration PeerConnectionObserver RTCDataChannelObserver RTCIceServer RTCDataChannelInit RTCIceCandidate RTCDataChannelBuffer]
+  (:import [dev.onvoid.webrtc PeerConnectionFactory RTCConfiguration PeerConnectionObserver RTCDataChannelObserver RTCIceServer RTCDataChannelInit RTCIceCandidate RTCDataChannelBuffer RTCSessionDescription RTCSdpType RTCOfferOptions]
            [dev.onvoid.webrtc.media.audio HeadlessAudioDeviceModule]
            [java.util ArrayList]
            [java.net InetAddress InetSocketAddress]
@@ -16,187 +16,125 @@
    :pwd (second (re-find #"a=ice-pwd:([^\r\n]+)" sdp))})
 
 (defn parse-candidate [candidate-sdp]
-  ;; candidate:2498732755 1 udp 2122260223 192.168.0.2 48355 typ host ...
   (let [parts (.split candidate-sdp " ")]
     {:ip (get parts 4)
      :port (Integer/parseInt (get parts 5))}))
 
-(defn create-offer [pc]
-  (let [p (promise)]
-    (.createOffer pc (dev.onvoid.webrtc.RTCOfferOptions.)
-                  (reify dev.onvoid.webrtc.CreateSessionDescriptionObserver
-                    (onSuccess [_ description]
-                      (deliver p description))
-                    (onFailure [_ error]
-                      (deliver p (ex-info "Create offer failed" {:error error})))))
-    @p))
-
-(defn set-local-description [pc description]
-  (let [p (promise)]
-    (.setLocalDescription pc description
-                          (reify dev.onvoid.webrtc.SetSessionDescriptionObserver
-                            (onSuccess [_]
-                              (deliver p true))
-                            (onFailure [_ error]
-                              (deliver p (ex-info "Set local description failed" {:error error})))))
-    @p))
-
-(defn set-remote-description [pc description]
-  (let [p (promise)]
-    (.setRemoteDescription pc description
-                           (reify dev.onvoid.webrtc.SetSessionDescriptionObserver
-                             (onSuccess [_]
-                               (deliver p true))
-                             (onFailure [_ error]
-                               (deliver p (ex-info "Set remote description failed" {:error error})))))
-    @p))
-
 (deftest test-webrtc-data-channel
-  (println "Initializing PeerConnectionFactory...")
+  (println "Starting WebRTC integration test...")
   (let [adm (HeadlessAudioDeviceModule.)
         factory (PeerConnectionFactory. adm)
         config (RTCConfiguration.)
         ice-servers (ArrayList.)]
-
-    ;; Use Google STUN server
-    (let [ice-server (RTCIceServer.)]
-      (set! (.urls ice-server) (doto (ArrayList.) (.add "stun:stun.l.google.com:19302")))
-      (.add ice-servers ice-server))
     (set! (.iceServers config) ice-servers)
 
-    (let [pc-promise (promise)
-          candidates (atom [])
-          remote-creds (atom nil)
-
-          ;; Start Datachannel-clj server
-          local-ip (get-local-ip)
+    (let [local-ip (get-local-ip)
           port (+ 20000 (rand-int 5000))
           ice-ufrag "testufrag"
-          ice-pwd "testpwd"
-          server (dc/listen port :host local-ip :ice-ufrag ice-ufrag :ice-pwd ice-pwd)
+          ice-pwd "testpassword12345678901234567890" ;; Must be at least 22 chars
+
+          ;; Clojure server (passive)
+          server (dc/listen port :host local-ip :ice-ufrag ice-ufrag :ice-pwd ice-pwd :dtls-client false)
           server-cert-fingerprint (:fingerprint (:cert-data server))
+
+          remote-creds (atom nil)
+          dc-open-promise (promise)
           server-message-promise (promise)
+          dc-message-promise (promise)
 
           observer (reify PeerConnectionObserver
                      (onIceCandidate [_ candidate]
-                       (println "Gathered candidate:" (.sdp candidate))
-                       (swap! candidates conj candidate)
-                       ;; Send STUN Binding Request to this candidate to punch hole
+                       (println "Java gathered candidate:" (.sdp candidate))
                        (when-let [creds @remote-creds]
                          (try
                            (let [cand-info (parse-candidate (.sdp candidate))
                                  req (stun/make-binding-request ice-ufrag (:ufrag creds) (:pwd creds))
                                  addr (InetSocketAddress. ^String (:ip cand-info) (int (:port cand-info)))]
-                             (println "Sending STUN Binding Request to" addr)
+                             (println "Clojure sending STUN Request to Java at" addr)
                              (.send (:channel server) req addr))
-                           (catch Exception e
-                             (println "Failed to send STUN request:" e)))))
-                     (onIceConnectionChange [_ state]
-                       (println "ICE Connection State:" state))
-                     (onConnectionChange [_ state]
-                       (println "Connection State:" state))
-                     (onSignalingChange [_ state])
-                     (onIceGatheringChange [_ state])
-                     (onIceCandidatesRemoved [_ candidates])
-                     (onAddStream [_ stream])
-                     (onRemoveStream [_ stream])
-                     (onDataChannel [_ channel])
-                     (onRenegotiationNeeded [_])
-                     (onAddTrack [_ receiver streams])
-                     (onTrack [_ transceiver])
-                     (onIceCandidateError [_ event]
-                       (println "ICE Candidate Error:" (.address event) (.port event) (.errorText event))))
+                           (catch Exception e (println "Error sending STUN:" e)))))
+                     (onIceConnectionChange [_ state] (println "Java ICE Connection State:" state))
+                     (onConnectionChange [_ state] (println "Java Connection State:" state))
+                     (onDataChannel [_ _])
+                     (onSignalingChange [_ _]) (onIceGatheringChange [_ _]) (onIceCandidatesRemoved [_ _])
+                     (onAddStream [_ _]) (onRemoveStream [_ _]) (onRenegotiationNeeded [_])
+                     (onAddTrack [_ _ _]) (onTrack [_ _]) (onIceCandidateError [_ _]))
 
           pc (.createPeerConnection factory config observer)
-
           dc-init (RTCDataChannelInit.)
           _ (set! (.ordered dc-init) true)
           data-channel (.createDataChannel pc "test" dc-init)
 
-          dc-open-promise (promise)
-          dc-message-promise (promise)
-
-          dc-observer (reify RTCDataChannelObserver
-                        (onBufferedAmountChange [_ amount])
-                        (onStateChange [_]
-                          (println "DataChannel State:" (.state data-channel))
-                          (when (= (.state data-channel) dev.onvoid.webrtc.RTCDataChannelState/OPEN)
-                            (deliver dc-open-promise true)))
-                        (onMessage [_ buffer]
-                          (let [data (.data buffer)
-                                bytes (byte-array (.remaining data))]
-                            (.get data bytes)
-                            (deliver dc-message-promise (String. bytes "UTF-8")))))
-
-          _ (.registerObserver data-channel dc-observer)]
-
-      (println "Server started on" local-ip ":" port "Fingerprint:" server-cert-fingerprint "IP:" local-ip)
+          _ (.registerObserver data-channel (reify RTCDataChannelObserver
+                                              (onBufferedAmountChange [_ _])
+                                              (onStateChange [_]
+                                                (println "Java DataChannel State:" (.getState data-channel))
+                                                (when (= (.getState data-channel) dev.onvoid.webrtc.RTCDataChannelState/OPEN)
+                                                  (deliver dc-open-promise true)))
+                                              (onMessage [_ buffer]
+                                                (let [data (.data buffer)
+                                                      bytes (byte-array (.remaining data))]
+                                                  (.get data bytes)
+                                                  (let [s (String. bytes "UTF-8")]
+                                                    (println "Java received message:" s)
+                                                    (deliver dc-message-promise s))))))]
 
       (reset! (:on-message server)
               (fn [msg]
                 (let [s (String. msg "UTF-8")]
+                  (println "Clojure received message:" s)
                   (deliver server-message-promise s)
                   (dc/send-msg server "Pong from clj"))))
 
       (try
-        ;; 1. Create Offer
-        (let [offer (create-offer pc)]
-          (println "Offer created:\n" (.sdp offer))
-          (reset! remote-creds (extract-ice-credentials (.sdp offer)))
-          (println "Remote Creds:" @remote-creds)
+        (let [offer-p (promise)]
+          (.createOffer pc (RTCOfferOptions.)
+                        (reify dev.onvoid.webrtc.CreateSessionDescriptionObserver
+                          (onSuccess [_ desc] (deliver offer-p desc))
+                          (onFailure [_ err] (deliver offer-p err))))
+          (let [offer @offer-p]
+            (is (instance? RTCSessionDescription offer) "Offer creation failed")
+            (reset! remote-creds (extract-ice-credentials (.sdp offer)))
 
-          ;; 2. Set Local Description
-          (set-local-description pc offer)
-          (println "Local Description set")
+            (.setLocalDescription pc offer (reify dev.onvoid.webrtc.SetSessionDescriptionObserver
+                                             (onSuccess [_]) (onFailure [_ err] (println "SetLocal failed:" err))))
 
-          (let [sdp-type dev.onvoid.webrtc.RTCSdpType/ANSWER
-                ;; Construct minimal SDP Answer
-                sdp-str (str "v=0\r\n"
-                             "o=- 123456789 2 IN IP4 " local-ip "\r\n"
-                             "s=-\r\n"
-                             "t=0 0\r\n"
-                             "a=group:BUNDLE 0\r\n"
-                             "m=application " port " UDP/DTLS/SCTP webrtc-datachannel\r\n"
-                             "c=IN IP4 " local-ip "\r\n"
-                             "a=setup:passive\r\n"
-                             "a=mid:0\r\n"
-                             "a=sctp-port:5000\r\n"
-                             "a=max-message-size:100000\r\n"
-                             "a=fingerprint:sha-256 " server-cert-fingerprint "\r\n"
-                             "a=ice-ufrag:" ice-ufrag "\r\n"
-                             "a=ice-pwd:" ice-pwd "\r\n"
-                             "a=ice-lite\r\n"
-                             "a=rtcp-mux\r\n")
+            (let [answer-sdp (str "v=0\r\n"
+                                  "o=- 123456789 2 IN IP4 " local-ip "\r\n"
+                                  "s=-\r\n"
+                                  "t=0 0\r\n"
+                                  "a=group:BUNDLE 0\r\n"
+                                  "m=application " port " UDP/DTLS/SCTP webrtc-datachannel\r\n"
+                                  "c=IN IP4 " local-ip "\r\n"
+                                  "a=setup:passive\r\n"
+                                  "a=mid:0\r\n"
+                                  "a=sctp-port:5000\r\n"
+                                  "a=max-message-size:100000\r\n"
+                                  "a=fingerprint:sha-256 " server-cert-fingerprint "\r\n"
+                                  "a=ice-ufrag:" ice-ufrag "\r\n"
+                                  "a=ice-pwd:" ice-pwd "\r\n"
+                                  "a=ice-lite\r\n")
+                  answer (RTCSessionDescription. RTCSdpType/ANSWER answer-sdp)]
 
-                 answer (dev.onvoid.webrtc.RTCSessionDescription. sdp-type sdp-str)]
+              (.setRemoteDescription pc answer (reify dev.onvoid.webrtc.SetSessionDescriptionObserver
+                                                 (onSuccess [_]) (onFailure [_ err] (println "SetRemote failed:" err))))
 
-            (println "Setting Remote Description (Answer)...")
-            (println "Answer SDP:\n" sdp-str)
-            (set-remote-description pc answer)
-            (println "Remote Description set.")
+              (let [cand-str (str "candidate:1 1 UDP 2130706431 " local-ip " " port " typ host")]
+                (.addIceCandidate pc (RTCIceCandidate. "0" 0 cand-str)))
 
-            (let [candidate-str (str "candidate:1 1 UDP 2130706431 " local-ip " " port " typ host")]
-              (println "Adding ICE Candidate:" candidate-str)
-              (.addIceCandidate pc (RTCIceCandidate. "0" 0 candidate-str)))
+              (println "Waiting for DataChannel OPEN...")
+              (if (deref dc-open-promise 20000 false)
+                (do
+                  (println "DataChannel OPEN! Sending 'Hello from Java'...")
+                  (let [buf (ByteBuffer/wrap (.getBytes "Hello from Java" "UTF-8"))
+                        dc-buf (RTCDataChannelBuffer. buf false)]
+                    (.send data-channel dc-buf))
 
-            ;; Now wait for connection
-            (println "Waiting for DataChannel OPEN...")
-            (is (deref dc-open-promise 10000 false) "DataChannel failed to open")
-
-            (when (realized? dc-open-promise)
-              ;; Send message from Java -> Clj
-              (println "Sending 'Hello from Java'...")
-              (let [buffer (ByteBuffer/wrap (.getBytes "Hello from Java" "UTF-8"))
-                    dc-buffer (RTCDataChannelBuffer. buffer false)]
-                (.send data-channel dc-buffer))
-
-              ;; Verify receipt at Clj
-              (is (= "Hello from Java" (deref server-message-promise 5000 :timeout)))
-
-              ;; Verify receipt at Java (Pong)
-              (is (= "Pong from clj" (deref dc-message-promise 5000 :timeout))))))
-
+                  (is (= "Hello from Java" (deref server-message-promise 10000 :timeout)))
+                  (is (= "Pong from clj" (deref dc-message-promise 10000 :timeout))))
+                (is false "DataChannel failed to open (timeout)")))))
         (finally
+          (dc/close server)
           (.close pc)
           (.dispose factory)
           (.dispose adm))))))

--- a/test_output.log
+++ b/test_output.log
@@ -1,0 +1,74 @@
+
+Testing datachannel.webrtc-integration-test
+Starting WebRTC integration test...
+Java ICE Connection State: #object[dev.onvoid.webrtc.RTCIceConnectionState 0x1b09fa52 CHECKING]
+Java gathered candidate: candidate:1849919641 1 udp 2122260223 192.168.0.2 51737 typ host generation 0 ufrag Bw8z network-id 1
+Clojure sending STUN Request to Java at #object[java.net.InetSocketAddress 0x6ce2211 /192.168.0.2:51737]
+Accepted connection from Waiting for DataChannel OPEN...
+#object[java.net.InetSocketAddress 0x3558c73b /192.168.0.2:51737]
+Java Connection State: #object[dev.onvoid.webrtc.RTCPeerConnectionState 0x714edc58 CONNECTING]
+Received STUN packet type: 0x0101 from #object[java.net.InetSocketAddress 0x3558c73b /192.168.0.2:51737]
+Received STUN Binding Request from #object[java.net.InetSocketAddress 0x3558c73b /192.168.0.2:51737]
+  - USE-CANDIDATE present
+  - ICE-CONTROLLING present
+Sending STUN Binding Success Response to #object[java.net.InetSocketAddress 0x3558c73b /192.168.0.2:51737]
+DTLS Handshake Status: #object[javax.net.ssl.SSLEngineResult$HandshakeStatus 0x7afc6165 NEED_TASK]
+DTLS Handshake Status: #object[javax.net.ssl.SSLEngineResult$HandshakeStatus 0x35b5d718 NEED_WRAP]
+DTLS Handshake Status: #object[javax.net.ssl.SSLEngineResult$HandshakeStatus 0x737cad90 NEED_UNWRAP]
+Sending 1 DTLS handshake packets
+Received STUN Binding Request from #object[java.net.InetSocketAddress 0x3558c73b /192.168.0.2:51737]
+  - USE-CANDIDATE present
+  - ICE-CONTROLLING present
+Sending STUN Binding Success Response to #object[java.net.InetSocketAddress 0x3558c73b /192.168.0.2:51737]
+DTLS Handshake Status: #object[javax.net.ssl.SSLEngineResult$HandshakeStatus 0x737cad90 NEED_UNWRAP]
+DTLS Handshake Status: #object[javax.net.ssl.SSLEngineResult$HandshakeStatus 0x7afc6165 NEED_TASK]
+DTLS Handshake Status: #object[javax.net.ssl.SSLEngineResult$HandshakeStatus 0x35b5d718 NEED_WRAP]
+DTLS Handshake Status: #object[javax.net.ssl.SSLEngineResult$HandshakeStatus 0x35b5d718 NEED_WRAP]
+DTLS Handshake Status: #object[javax.net.ssl.SSLEngineResult$HandshakeStatus 0x35b5d718 NEED_WRAP]
+DTLS Handshake Status: #object[javax.net.ssl.SSLEngineResult$HandshakeStatus 0x35b5d718 NEED_WRAP]
+DTLS Handshake Status: #object[javax.net.ssl.SSLEngineResult$HandshakeStatus 0x35b5d718 NEED_WRAP]
+DTLS Handshake Status: #object[javax.net.ssl.SSLEngineResult$HandshakeStatus 0x737cad90 NEED_UNWRAP]
+Sending 5 DTLS handshake packets
+DTLS Handshake Status: #object[javax.net.ssl.SSLEngineResult$HandshakeStatus 0x737cad90 NEED_UNWRAP]
+DTLS Handshake Status: #object[javax.net.ssl.SSLEngineResult$HandshakeStatus 0x737cad90 NEED_UNWRAP]
+DTLS Handshake Status: #object[javax.net.ssl.SSLEngineResult$HandshakeStatus 0x737cad90 NEED_UNWRAP]
+DTLS Handshake Status: #object[javax.net.ssl.SSLEngineResult$HandshakeStatus 0x737cad90 NEED_UNWRAP]
+DTLS Handshake Status: #object[javax.net.ssl.SSLEngineResult$HandshakeStatus 0x737cad90 NEED_UNWRAP]
+DTLS Handshake Status: #object[javax.net.ssl.SSLEngineResult$HandshakeStatus 0x7afc6165 NEED_TASK]
+DTLS Handshake Status: #object[javax.net.ssl.SSLEngineResult$HandshakeStatus 0x2b29bd39 NEED_UNWRAP_AGAIN]
+DTLS Handshake Status: #object[javax.net.ssl.SSLEngineResult$HandshakeStatus 0x7afc6165 NEED_TASK]
+DTLS Handshake Status: #object[javax.net.ssl.SSLEngineResult$HandshakeStatus 0x2b29bd39 NEED_UNWRAP_AGAIN]
+DTLS Handshake Status: #object[javax.net.ssl.SSLEngineResult$HandshakeStatus 0x7afc6165 NEED_TASK]
+DTLS Handshake Status: #object[javax.net.ssl.SSLEngineResult$HandshakeStatus 0x2b29bd39 NEED_UNWRAP_AGAIN]
+DTLS Handshake Status: #object[javax.net.ssl.SSLEngineResult$HandshakeStatus 0x2b29bd39 NEED_UNWRAP_AGAIN]
+DTLS Handshake Status: #object[javax.net.ssl.SSLEngineResult$HandshakeStatus 0x35b5d718 NEED_WRAP]
+DTLS Handshake Status: #object[javax.net.ssl.SSLEngineResult$HandshakeStatus 0x35b5d718 NEED_WRAP]
+DTLS Handshake Status: #object[javax.net.ssl.SSLEngineResult$HandshakeStatus 0x35b5d718 NEED_WRAP]
+DTLS Handshake Status: #object[javax.net.ssl.SSLEngineResult$HandshakeStatus 0x35b5d718 NEED_WRAP]
+Sending 4 DTLS handshake packets
+Java Connection State: #object[dev.onvoid.webrtc.RTCPeerConnectionState 0x6ce19a0 CONNECTED]
+Java ICE Connection State: #object[dev.onvoid.webrtc.RTCIceConnectionState 0x3db17e63 CONNECTED]
+Java ICE Connection State: #object[dev.onvoid.webrtc.RTCIceConnectionState 0x17dde17f COMPLETED]
+Received STUN Binding Request from #object[java.net.InetSocketAddress 0x3558c73b /192.168.0.2:51737]
+  - USE-CANDIDATE present
+  - ICE-CONTROLLING present
+Sending STUN Binding Success Response to #object[java.net.InetSocketAddress 0x3558c73b /192.168.0.2:51737]
+Received SCTP INIT, tag: 2549897051
+Sending SCTP INIT_ACK
+Received SCTP COOKIE_ECHO
+Sending SCTP COOKIE_ACK
+Java DataChannel State: #object[dev.onvoid.webrtc.RTCDataChannelState 0x107653c0 OPEN]
+Received DCEP message type: 3
+Sending DCEP ACK for stream 0
+DataChannel OPEN! Sending 'Hello from Java'...
+Clojure received message: Hello from Java
+Offering message to queue: Pong from clj with SSN 1
+Java received message: Pong from clj
+Java ICE Connection State: #object[dev.onvoid.webrtc.RTCIceConnectionState 0x66034b77 CLOSED]
+Java Connection State: #object[dev.onvoid.webrtc.RTCPeerConnectionState 0x50f763b2 CLOSED]
+
+Ran 1 tests containing 3 assertions.
+0 failures, 0 errors.
+{:test 1, :pass 3, :fail 0, :error 0, :type :summary}
+VM attach current thread failed
+Failed to attach thread 140479855143808


### PR DESCRIPTION
This PR fixes several critical bugs in the DTLS, SCTP, and STUN implementations that were preventing successful Data Channel establishment with the reference Java WebRTC library. Key fixes include SCTP checksum endianness, DTLS record size management, and proper SCTP/DCEP handshaking. The `datachannel.webrtc-integration-test` is now fully functional and enabled in the test suite.

Fixes #31

---
*PR created automatically by Jules for task [14532103959372818356](https://jules.google.com/task/14532103959372818356) started by @alpeware*