### PR TITLE
⚡ Optimize SCTP parameter encoding by reusing empty byte array

### DIFF
--- a/src/datachannel/sctp.clj
+++ b/src/datachannel/sctp.clj
@@ -5,6 +5,8 @@
    [java.nio ByteBuffer ByteOrder]
    [java.util.zip CRC32C]))
 
+(def ^:private EMPTY-BYTE-ARRAY (byte-array 0))
+
 ;; Chunk types
 (def chunk-types
   {:data 0
@@ -110,7 +112,7 @@
 (defn encode-params [^ByteBuffer buf params]
   (doseq [[k v] params]
     (let [type-code (if (keyword? k) (get parameters k) k)
-          v-bytes (if (bytes? v) v (byte-array 0))
+          v-bytes (if (bytes? v) v EMPTY-BYTE-ARRAY)
           len (+ 4 (alength v-bytes))
           padding (pad len)]
       (.putShort buf (unchecked-short type-code))


### PR DESCRIPTION
💡 **What:** The optimization implemented is the replacement of redundant `(byte-array 0)` allocations with a shared, private static `EMPTY-BYTE-ARRAY` constant in `src/datachannel/sctp.clj`.

🎯 **Why:** In the `encode-params` function, which is part of the SCTP encoding hot path, a new empty byte array was being allocated every time a parameter value was not already a byte array. While zero-length arrays are small, frequent allocations in a high-traffic protocol implementation can lead to unnecessary heap churn and increased garbage collection pressure.

📊 **Measured Improvement:** Due to the absence of Clojure CLI tools in the environment and network restrictions preventing their installation, a direct performance measurement was not possible. However, this is a standard and safe performance optimization in JVM-based languages to avoid redundant object allocations, especially for immutable-in-practice objects like zero-length arrays.

---
*PR created automatically by Jules for task [8878870035724166271](https://jules.google.com/task/8878870035724166271) started by @alpeware*