### PR TITLE
🔒 [security fix] Use SecureRandom for STUN and SCTP sensitive values

### DIFF
--- a/src/datachannel/core.clj
+++ b/src/datachannel/core.clj
@@ -6,7 +6,10 @@
            [java.net InetSocketAddress StandardSocketOptions]
            [java.nio.channels DatagramChannel Selector SelectionKey]
            [javax.net.ssl SSLEngine SSLEngineResult SSLEngineResult$Status SSLEngineResult$HandshakeStatus]
-           [java.util.concurrent LinkedBlockingQueue TimeUnit]))
+           [java.util.concurrent LinkedBlockingQueue TimeUnit]
+           [java.security SecureRandom]))
+
+(defonce ^:private secure-rand (SecureRandom.))
 
 (def buffer-size 65536)
 
@@ -219,7 +222,7 @@
         selector (Selector/open)
         peer-addr (InetSocketAddress. host port)
         sctp-out (LinkedBlockingQueue.)
-        local-ver-tag (rand-int 2147483647)
+        local-ver-tag (.nextInt secure-rand 2147483647)
         connection {:sctp-out sctp-out
                     :state (atom {:remote-ver-tag 0
                                   :local-ver-tag local-ver-tag
@@ -264,7 +267,7 @@
         channel (DatagramChannel/open)
         selector (Selector/open)
         sctp-out (LinkedBlockingQueue.)
-        local-ver-tag (rand-int 2147483647)
+        local-ver-tag (.nextInt secure-rand 2147483647)
         connection {:sctp-out sctp-out
                     :state (atom {:remote-ver-tag 0
                                   :local-ver-tag local-ver-tag

--- a/src/datachannel/stun.clj
+++ b/src/datachannel/stun.clj
@@ -3,7 +3,10 @@
            [java.net InetSocketAddress]
            [javax.crypto Mac]
            [javax.crypto.spec SecretKeySpec]
-           [java.util.zip CRC32]))
+           [java.util.zip CRC32]
+           [java.security SecureRandom]))
+
+(defonce ^:private secure-rand (SecureRandom.))
 
 (def magic-cookie 0x2112A442)
 
@@ -46,7 +49,7 @@
   (let [buf (ByteBuffer/allocate 1024)
         _ (.order buf ByteOrder/BIG_ENDIAN)
         tx-id (byte-array 12)]
-    (.nextBytes (java.util.Random.) tx-id)
+    (.nextBytes secure-rand tx-id)
 
     ;; Header
     (put-unsigned-short buf 0x0001) ;; Binding Request
@@ -75,7 +78,7 @@
     ;; Since we are passive/lite, we usually are controlled.
     (put-unsigned-short buf ATTR_ICE_CONTROLLED)
     (put-unsigned-short buf 8)
-    (.putLong buf (.nextLong (java.util.Random.)))
+    (.putLong buf (.nextLong secure-rand))
 
     ;; Update Header Length for MI (FINGERPRINT comes after, but length in header for MI should only include MI)
     (let [len-before-mi (- (.position buf) 20)
@@ -118,7 +121,7 @@
   (let [buf (ByteBuffer/allocate 1024)
         _ (.order buf ByteOrder/BIG_ENDIAN)
         tx-id (byte-array 12)]
-    (.nextBytes (java.util.Random.) tx-id)
+    (.nextBytes secure-rand tx-id)
 
     ;; Header
     (put-unsigned-short buf 0x0001) ;; Binding Request


### PR DESCRIPTION
### 🎯 What: The vulnerability fixed
The codebase was using `java.util.Random` and Clojure's `rand-int` (which relies on `java.util.Random`) for generating sensitive network identifiers:
- STUN Transaction IDs
- ICE-CONTROLLED tie-breakers
- SCTP Verification Tags (`local-ver-tag`)

### ⚠️ Risk: The potential impact if left unfixed
`java.util.Random` is a linear congruential generator that is not cryptographically secure. An attacker who can observe a few values can predict future values. This predictability could allow an attacker to:
- Predict and spoof STUN transaction IDs, leading to failed connectivity or manipulated signaling.
- Predict SCTP verification tags, enabling blind injection of SCTP packets or session hijacking.
- Predict ICE tie-breakers.

### 🛡️ Solution: How the fix addresses the vulnerability
The fix replaces all usages of insecure PRNGs in `src/datachannel/stun.clj` and `src/datachannel/core.clj` with `java.security.SecureRandom`.
- A single, private, `defonce`'d `SecureRandom` instance is used per namespace to ensure thread safety and efficient resource usage.
- `(.nextBytes secure-rand ...)` is used for byte-array generation.
- `(.nextLong secure-rand)` and `(.nextInt secure-rand ...)` are used for long and integer values respectively.

---
*PR created automatically by Jules for task [11087657693122697871](https://jules.google.com/task/11087657693122697871) started by @alpeware*