### PR TITLE
Add webrtc-java documentation to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,41 @@ clojure -M:test -e "(require 'datachannel.sctp-test) (clojure.test/run-tests 'da
 ### Reference Implementation
 We use `dev.onvoid.webrtc/webrtc-java` as the reference implementation for compliance testing. Integration tests in `test/datachannel/webrtc_integration_test.clj` and `test/datachannel/stun_webrtc_integration_test.clj` verify interoperability with this library.
 
+## Reference Implementation (webrtc-java) Guide
+
+### Data Channels (`RTCDataChannelInit`)
+- **Reliability and Ordering**:
+    - `ordered`: Default `true`.
+    - **Reliable** (default): `maxPacketLifeTime = -1`, `maxRetransmits = -1`.
+    - **Time-limited**: Set `maxPacketLifeTime` (ms), `maxRetransmits = -1`.
+    - **Count-limited**: Set `maxPacketLifeTime = -1`, `maxRetransmits` (count).
+- **Other options**:
+    - `negotiated`: If `true`, the channel is out-of-band negotiated. Default `false`.
+    - `id`: Manual ID (0-65535). Default `-1` (auto-assigned).
+    - `protocol`: Sub-protocol name string.
+    - `priority`: `RTCPriorityType` (e.g., `VERY_LOW`, `LOW`, `MEDIUM`, `HIGH`).
+
+### Port Allocator (`PortAllocatorConfig`)
+- `minPort` / `maxPort`: Restrict ephemeral port range for candidates. `0` means unspecified.
+- **Common Flags**:
+    - `PORTALLOCATOR_DISABLE_UDP`, `PORTALLOCATOR_DISABLE_STUN`, `PORTALLOCATOR_DISABLE_RELAY`, `PORTALLOCATOR_DISABLE_TCP`.
+    - `PORTALLOCATOR_ENABLE_IPV6`, `PORTALLOCATOR_ENABLE_SHARED_SOCKET`.
+    - `PORTALLOCATOR_DISABLE_ADAPTER_ENUMERATION`, `PORTALLOCATOR_DISABLE_COSTLY_NETWORKS`.
+
+### RTC Stats (`RTCStatsType`)
+Stats are collected via `RTCPeerConnection.getStats()`.
+- **Common Types**: `INBOUND_RTP`, `OUTBOUND_RTP`, `DATA_CHANNEL`, `TRANSPORT`, `CANDIDATE_PAIR`, `LOCAL_CANDIDATE`, `REMOTE_CANDIDATE`.
+- **Useful Attributes**:
+    - `INBOUND_RTP`: `packetsReceived`, `bytesReceived`, `packetsLost`, `jitter`.
+    - `OUTBOUND_RTP`: `packetsSent`, `bytesSent`.
+    - `CANDIDATE_PAIR`: `nominated`, `state`, `currentRoundTripTime`, `bytesSent`, `bytesReceived`.
+
+### Logging
+Managed via `dev.onvoid.webrtc.logging.Logging`.
+- **Severity Levels**: `VERBOSE`, `INFO`, `WARNING`, `ERROR`, `NONE`.
+- **Configuration**: `logToDebug(severity)`, `logThreads(bool)`, `logTimestamps(bool)`.
+- **Custom Sinks**: Implement `LogSink` interface and register via `addLogSink(severity, sink)`.
+
 ## Project Structure
 - `src/datachannel/`: Source code.
 - `test/datachannel/`: Test suite.


### PR DESCRIPTION
Updated `AGENTS.md` with relevant documentation from the `webrtc-java` reference implementation. The added content covers Data Channel settings, Port Allocator flags, RTC Stats, and Logging configurations, which are essential for maintaining and extending the library's integration tests. verified the changes by running the full test suite.

Fixes #47

---
*PR created automatically by Jules for task [8228904981208409955](https://jules.google.com/task/8228904981208409955) started by @alpeware*