### PR TITLE
Fix regression in datachannel.integration-test and improve resource cleanup

### DIFF
--- a/src/datachannel/core.clj
+++ b/src/datachannel/core.clj
@@ -20,6 +20,10 @@
   (when ch
     (try (.close ch) (catch Exception _))))
 
+(defn- close-selector [sel]
+  (when sel
+    (try (.close sel) (catch Exception _))))
+
 (defn- handle-sctp-packet [packet connection]
   (let [chunks (:chunks packet)
         state (:state connection)]
@@ -200,7 +204,9 @@
                             (try (-> (ByteBuffer/wrap app-data) sctp/decode-packet (handle-sctp-packet connection))
                                  (catch Exception e (println "SCTP Decode Error (Handshake):" e)))))))))))
             (catch Exception e
-              (println "Error in run-loop processing:" e)))
+              (if-not (or (instance? java.nio.channels.ClosedChannelException e)
+                          (instance? java.nio.channels.ClosedSelectorException e))
+                (println "Error in run-loop processing:" e))))
 
           (.clear net-in-loop)
           (let [count (.select selector 10)]
@@ -233,7 +239,8 @@
                     :cert-data cert-data
                     :ice-ufrag (:ice-ufrag options)
                     :ice-pwd (:ice-pwd options)
-                    :channel channel}]
+                    :channel channel
+                    :selector selector}]
     (.configureBlocking channel false)
     (.connect channel peer-addr)
 
@@ -242,7 +249,9 @@
                 (try
                   (run-loop channel selector engine peer-addr connection)
                   (catch Exception e
-                    (println "Connection Loop Error:" e)))))]
+                    (if-not (or (instance? java.nio.channels.ClosedChannelException e)
+                                (instance? java.nio.channels.ClosedSelectorException e))
+                      (println "Connection Loop Error:" e))))))]
       (.start t))
 
     (let [init-chunk {:type :init
@@ -278,7 +287,8 @@
                     :cert-data cert-data
                     :ice-ufrag (:ice-ufrag options)
                     :ice-pwd (:ice-pwd options)
-                    :channel channel}]
+                    :channel channel
+                    :selector selector}]
     (.configureBlocking channel false)
     (if-let [host (:host options)]
       (.bind channel (InetSocketAddress. ^String host (int port)))
@@ -297,7 +307,9 @@
                     (.flip temp-buf)
                     (run-loop channel selector engine peer-addr connection temp-buf))
                   (catch Exception e
-                    (println "Server Loop Error:" e)))))]
+                    (if-not (or (instance? java.nio.channels.ClosedChannelException e)
+                                (instance? java.nio.channels.ClosedSelectorException e))
+                      (println "Server Loop Error:" e))))))]
       (.start t))
 
     connection))
@@ -324,4 +336,5 @@
      (.offer (:sctp-out connection) packet)))
 
 (defn close [connection]
-  (close-channel (:channel connection)))
+  (close-channel (:channel connection))
+  (close-selector (:selector connection)))


### PR DESCRIPTION
Investigated and resolved a regression in `datachannel.integration-test` where `java.nio.channels.ClosedChannelException` was being logged during connection teardown.

Key changes:
- Modified `src/datachannel/core.clj` to suppress `ClosedChannelException` and `ClosedSelectorException` in background threads, as these are expected when a connection is intentionally closed.
- Updated `connect` and `listen` to include the `Selector` in the returned `connection` map.
- Updated the `close` function to explicitly close the `Selector`, ensuring that any thread blocked in `.select()` is immediately woken up and resources are properly released.
- Verified the fix using a reproduction test that repeatedly opens and closes connections, as well as by running the full test suite.
- Cleaned up the environment by removing transient directories (`.clojure-env`, `.cpcache`) before submission.

Fixes #46

---
*PR created automatically by Jules for task [16871938374180735841](https://jules.google.com/task/16871938374180735841) started by @alpeware*