### PR TITLE
🔒 fix: Use secure random string for SCTP cookie

### DIFF
--- a/src/datachannel/core.clj
+++ b/src/datachannel/core.clj
@@ -84,13 +84,14 @@
         (do
           (swap! state assoc :remote-ver-tag (:init-tag chunk)
                              :remote-tsn (dec (:initial-tsn chunk)))
-          (let [init-ack {:type :init-ack
+          (let [cookie-bytes (let [b (byte-array 32)] (.nextBytes secure-rand b) b)
+                init-ack {:type :init-ack
                           :init-tag (:local-ver-tag @state)
                           :a-rwnd 100000
                           :outbound-streams (:inbound-streams chunk)
                           :inbound-streams (:outbound-streams chunk)
                           :initial-tsn (:next-tsn @state)
-                          :params {:cookie (.getBytes (str (System/currentTimeMillis)) "UTF-8")}}
+                          :params {:cookie cookie-bytes}}
                 packet {:src-port (:dst-port packet)
                         :dst-port (:src-port packet)
                         :verification-tag (:init-tag chunk)


### PR DESCRIPTION
🎯 **What:** Fixed a vulnerability where the SCTP cookie was generated predictably using `System/currentTimeMillis`.
⚠️ **Risk:** An attacker could predict the SCTP cookie, potentially allowing them to hijack or spoof connections during the SCTP handshake phase.
🛡️ **Solution:** Replaced the timestamp-based string with a cryptographically secure 32-byte array, generated using `java.security.SecureRandom`.

---
*PR created automatically by Jules for task [4178741480295578932](https://jules.google.com/task/4178741480295578932) started by @alpeware*