### PR TITLE
🧹 Code Health: Extract SCTP padding logic into helper function

### DIFF
--- a/src/datachannel/sctp.clj
+++ b/src/datachannel/sctp.clj
@@ -109,16 +109,22 @@
                  (.position buf (+ (.position buf) padding))
                  (recur (assoc params type-key val-bytes))))))))))
 
+(defn- set-length-and-padding [^ByteBuffer buf start-pos]
+  (let [end-pos (.position buf)
+        len (- end-pos start-pos)
+        padding (pad len)]
+    (.putShort buf (+ start-pos 2) (unchecked-short len))
+    (dotimes [_ padding] (.put buf (byte 0)))))
+
 (defn encode-params [^ByteBuffer buf params]
   (doseq [[k v] params]
-    (let [type-code (if (keyword? k) (get parameters k) k)
-          v-bytes (if (bytes? v) v EMPTY-BYTE-ARRAY)
-          len (+ 4 (alength v-bytes))
-          padding (pad len)]
+    (let [start-pos (.position buf)
+          type-code (if (keyword? k) (get parameters k) k)
+          v-bytes (if (bytes? v) v EMPTY-BYTE-ARRAY)]
       (.putShort buf (unchecked-short type-code))
-      (.putShort buf (unchecked-short len))
+      (.putShort buf 0)
       (.put buf v-bytes)
-      (dotimes [_ padding] (.put buf (byte 0))))))
+      (set-length-and-padding buf start-pos))))
 
 (defmulti decode-chunk-payload (fn [type-key buf chunk-data val-len chunk-start flags] type-key))
 
@@ -337,11 +343,7 @@
       (when (:body chunk)
         (.put buf ^bytes (:body chunk))))
 
-    (let [end-pos (.position buf)
-          len (- end-pos start-pos)
-          padding (pad len)]
-      (.putShort buf (+ start-pos 2) (unchecked-short len))
-      (dotimes [_ padding] (.put buf (byte 0))))))
+    (set-length-and-padding buf start-pos)))
 
 (defn encode-packet [packet ^ByteBuffer buf]
   (let [orig-order (.order buf)]


### PR DESCRIPTION
🎯 **What:** Extracted duplicated logic for calculating the padded length and inserting byte alignment padding into a shared private helper function `set-length-and-padding` in `src/datachannel/sctp.clj`. 

💡 **Why:** Both `encode-params` and `encode-chunk` utilized an identical underlying pattern of computing the required length to insert into a 2-byte field at a fixed offset, followed by dynamically padding the buffer to ensure 4-byte boundaries. Extracting this directly into a function makes the encoding hot path more readable, guarantees future encoding components follow the same behavior, and removes error-prone duplicated byte-math.

✅ **Verification:** Verified that tests pass via `clojure -M:test -m datachannel.test-runner`, asserting that chunk and parameter serialization is structurally identical and correctly checksummed.

✨ **Result:** Codebase is more maintainable with reduced repetition of common bytebuffer manipulation patterns.

---
*PR created automatically by Jules for task [15150572256416089991](https://jules.google.com/task/15150572256416089991) started by @alpeware*