### PR TITLE
🧹 Refactor decode-chunk function for maintainability

### DIFF
--- a/src/datachannel/sctp.clj
+++ b/src/datachannel/sctp.clj
@@ -131,16 +131,22 @@
 (defmethod decode-chunk-payload :shutdown-ack [_ _ chunk-data _ _ _]
   chunk-data)
 
-(defmethod decode-chunk-payload :abort [_ buf chunk-data val-len chunk-start _]
+(defn decode-abort-chunk [buf chunk-data val-len chunk-start]
   (.position buf (+ chunk-start val-len))
   chunk-data)
 
-(defmethod decode-chunk-payload :default [_ buf chunk-data val-len _ _]
+(defmethod decode-chunk-payload :abort [_ buf chunk-data val-len chunk-start _]
+  (decode-abort-chunk buf chunk-data val-len chunk-start))
+
+(defn decode-default-chunk [buf chunk-data val-len]
   (let [body (byte-array val-len)]
     (.get buf body)
     (merge chunk-data {:body body})))
 
-(defmethod decode-chunk-payload :data [_ buf chunk-data val-len _ flags]
+(defmethod decode-chunk-payload :default [_ buf chunk-data val-len _ _]
+  (decode-default-chunk buf chunk-data val-len))
+
+(defn decode-data-chunk [buf chunk-data val-len flags]
   (let [tsn (get-unsigned-int buf)
         stream-id (get-unsigned-short buf)
         seq-num (get-unsigned-short buf)
@@ -158,7 +164,28 @@
             :beginning (bit-test flags 1)
             :ending (bit-test flags 0)})))
 
+(defmethod decode-chunk-payload :data [_ buf chunk-data val-len _ flags]
+  (decode-data-chunk buf chunk-data val-len flags))
+
+(defn decode-init-chunk [buf chunk-data val-len]
+  (let [init-tag (get-unsigned-int buf)
+        a-rwnd (get-unsigned-int buf)
+        outbound-streams (get-unsigned-short buf)
+        inbound-streams (get-unsigned-short buf)
+        initial-tsn (get-unsigned-int buf)
+        params-len (- val-len 20)]
+    (merge chunk-data
+           {:init-tag init-tag
+            :a-rwnd a-rwnd
+            :outbound-streams outbound-streams
+            :inbound-streams inbound-streams
+            :initial-tsn initial-tsn
+            :params (decode-params buf params-len)})))
+
 (defmethod decode-chunk-payload :init [_ buf chunk-data val-len _ _]
+  (decode-init-chunk buf chunk-data val-len))
+
+(defn decode-init-ack-chunk [buf chunk-data val-len]
   (let [init-tag (get-unsigned-int buf)
         a-rwnd (get-unsigned-int buf)
         outbound-streams (get-unsigned-short buf)
@@ -174,26 +201,17 @@
             :params (decode-params buf params-len)})))
 
 (defmethod decode-chunk-payload :init-ack [_ buf chunk-data val-len _ _]
-  (let [init-tag (get-unsigned-int buf)
-        a-rwnd (get-unsigned-int buf)
-        outbound-streams (get-unsigned-short buf)
-        inbound-streams (get-unsigned-short buf)
-        initial-tsn (get-unsigned-int buf)
-        params-len (- val-len 20)]
-    (merge chunk-data
-           {:init-tag init-tag
-            :a-rwnd a-rwnd
-            :outbound-streams outbound-streams
-            :inbound-streams inbound-streams
-            :initial-tsn initial-tsn
-            :params (decode-params buf params-len)})))
+  (decode-init-ack-chunk buf chunk-data val-len))
 
-(defmethod decode-chunk-payload :cookie-echo [_ buf chunk-data val-len _ _]
+(defn decode-cookie-echo-chunk [buf chunk-data val-len]
   (let [cookie (byte-array val-len)]
     (.get buf cookie)
     (merge chunk-data {:cookie cookie})))
 
-(defmethod decode-chunk-payload :sack [_ buf chunk-data _ _ _]
+(defmethod decode-chunk-payload :cookie-echo [_ buf chunk-data val-len _ _]
+  (decode-cookie-echo-chunk buf chunk-data val-len))
+
+(defn decode-sack-chunk [buf chunk-data]
   (let [cum-tsn-ack (get-unsigned-int buf)
         a-rwnd (get-unsigned-int buf)
         num-gap-ack-blocks (get-unsigned-short buf)
@@ -207,13 +225,22 @@
             :gap-blocks gap-blocks
             :duplicate-tsns duplicate-tsns})))
 
+(defmethod decode-chunk-payload :sack [_ buf chunk-data _ _ _]
+  (decode-sack-chunk buf chunk-data))
+
+(defn decode-heartbeat-chunk [buf chunk-data val-len]
+  (let [params (decode-params buf val-len)]
+    (merge chunk-data {:params params})))
+
 (defmethod decode-chunk-payload :heartbeat [_ buf chunk-data val-len _ _]
+  (decode-heartbeat-chunk buf chunk-data val-len))
+
+(defn decode-heartbeat-ack-chunk [buf chunk-data val-len]
   (let [params (decode-params buf val-len)]
     (merge chunk-data {:params params})))
 
 (defmethod decode-chunk-payload :heartbeat-ack [_ buf chunk-data val-len _ _]
-  (let [params (decode-params buf val-len)]
-    (merge chunk-data {:params params})))
+  (decode-heartbeat-ack-chunk buf chunk-data val-len))
 
 (defn decode-chunk [^ByteBuffer buf]
   (let [type-code (get-unsigned-byte buf)


### PR DESCRIPTION
🎯 **What:** Extracted the anonymous logic out of `defmethod decode-chunk-payload` implementations into specific, named functions (e.g., `decode-data-chunk`, `decode-init-chunk`).
💡 **Why:** This improves maintainability and readability by giving each chunk decoding routine its own distinct function signature and name, as suggested by the standard practice code health issue.
✅ **Verification:** Verified that property-based `packet-encoding-decoding-test` perfectly round trips the changes by running `clojure -M:test -m datachannel.test-runner`, assuring that exact parsing and data alignment behavior is intact.
✨ **Result:** The `src/datachannel/sctp.clj` code is much cleaner, and individual chunk processing routines can be tested or reasoned about in isolation.

---
*PR created automatically by Jules for task [11436154109933308717](https://jules.google.com/task/11436154109933308717) started by @alpeware*