### PR TITLE
🧹 [Code Health] Extract magic number for STUN priority to constant

### DIFF
--- a/src/datachannel/stun.clj
+++ b/src/datachannel/stun.clj
@@ -22,6 +22,8 @@
 (def ATTR_ICE_CONTROLLED 0x8029)
 (def ATTR_ICE_CONTROLLING 0x802A)
 
+(def DEFAULT_PRIORITY 1853824767)
+
 (defn- put-unsigned-short [^ByteBuffer buf val]
   (.putShort buf (unchecked-short val)))
 
@@ -72,7 +74,7 @@
     ;; PRIORITY (optional, but good practice)
     (put-unsigned-short buf ATTR_PRIORITY)
     (put-unsigned-short buf 4)
-    (.putInt buf 1853824767) ;; Some priority
+    (.putInt buf DEFAULT_PRIORITY)
 
     ;; ICE-CONTROLLING (or CONTROLLED)
     ;; Since we are passive/lite, we usually are controlled.


### PR DESCRIPTION
🎯 **What:** Extracted the hardcoded magic number `1853824767` in `src/datachannel/stun.clj` (used for the STUN priority attribute) into a new constant named `DEFAULT_PRIORITY`.

💡 **Why:** Hardcoded magic numbers reduce readability and make code harder to maintain. By assigning the value to a clear, named constant (`DEFAULT_PRIORITY`), the intent of the code is immediately apparent, aligning with best practices for code health.

✅ **Verification:** 
- The target magic number was correctly identified and replaced.
- Ran the full test suite (`clojure -M:test -m datachannel.test-runner`), and all 18 tests passed successfully, ensuring no existing STUN or DataChannel functionality was broken.
- Requested an automated code review which resulted in a `#Correct#` rating, confirming the safety and correctness of the change.

✨ **Result:** A small but meaningful improvement to the maintainability and readability of the STUN protocol implementation in the codebase.

---
*PR created automatically by Jules for task [6206991447287257871](https://jules.google.com/task/6206991447287257871) started by @alpeware*