### PR TITLE
🔒 Remove hardcoded keystore password in DTLS

### DIFF
--- a/src/datachannel/dtls.clj
+++ b/src/datachannel/dtls.clj
@@ -38,10 +38,11 @@
   (let [ks (KeyStore/getInstance "PKCS12")
         kmf (KeyManagerFactory/getInstance "SunX509")
         tmf (TrustManagerFactory/getInstance "SunX509")
-        ctx (SSLContext/getInstance "DTLS")]
+        ctx (SSLContext/getInstance "DTLS")
+        pwd (char-array (str (java.util.UUID/randomUUID)))]
     (.load ks nil nil)
-    (.setKeyEntry ks "webrtc" key (char-array "password") (into-array X509Certificate [cert]))
-    (.init kmf ks (char-array "password"))
+    (.setKeyEntry ks "webrtc" key pwd (into-array X509Certificate [cert]))
+    (.init kmf ks pwd)
     (.init tmf ks)
 
     ;; Create a trust manager that accepts the peer's certificate (for WebRTC DTLS-SRTP, we verify via fingerprint in SDP)


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed was a hardcoded keystore password (`"password"`) in `src/datachannel/dtls.clj`.
⚠️ **Risk:** The potential impact if left unfixed is that it exposes a static credential. While in this specific context the keystore is ephemeral and in-memory, hardcoded passwords in codebases can trigger security scanners and theoretically be reused maliciously or mistakenly if the code is refactored to persist the keystore.
🛡️ **Solution:** The solution replaces the static string `"password"` with a dynamically generated random UUID character array. Because this password is only needed locally in memory during the initialization of the `KeyStore` and `KeyManagerFactory`, a single-use random string securely satisfies the API requirements without introducing any permanent credentials to the codebase or environment.

---
*PR created automatically by Jules for task [12883216654037682961](https://jules.google.com/task/12883216654037682961) started by @alpeware*