### PR TITLE
🧹 Refactor `encode-chunk` payload logic into multimethod

### DIFF
--- a/src/datachannel/sctp.clj
+++ b/src/datachannel/sctp.clj
@@ -277,6 +277,55 @@
                      chunks)
                    chunks))})))
 
+(defmulti encode-chunk-payload (fn [type-key buf chunk] type-key))
+
+(defmethod encode-chunk-payload :data [_ ^ByteBuffer buf chunk]
+  (.putInt buf (unchecked-int (:tsn chunk)))
+  (.putShort buf (unchecked-short (:stream-id chunk)))
+  (.putShort buf (unchecked-short (:seq-num chunk)))
+  (.putInt buf (unchecked-int (get protocols (:protocol chunk) (:protocol chunk))))
+  (.put buf ^bytes (:payload chunk)))
+
+(defmethod encode-chunk-payload :init [_ ^ByteBuffer buf chunk]
+  (.putInt buf (unchecked-int (:init-tag chunk)))
+  (.putInt buf (unchecked-int (:a-rwnd chunk)))
+  (.putShort buf (unchecked-short (:outbound-streams chunk)))
+  (.putShort buf (unchecked-short (:inbound-streams chunk)))
+  (.putInt buf (unchecked-int (:initial-tsn chunk)))
+  (encode-params buf (:params chunk)))
+
+(defmethod encode-chunk-payload :init-ack [_ ^ByteBuffer buf chunk]
+  (.putInt buf (unchecked-int (:init-tag chunk)))
+  (.putInt buf (unchecked-int (:a-rwnd chunk)))
+  (.putShort buf (unchecked-short (:outbound-streams chunk)))
+  (.putShort buf (unchecked-short (:inbound-streams chunk)))
+  (.putInt buf (unchecked-int (:initial-tsn chunk)))
+  (encode-params buf (:params chunk)))
+
+(defmethod encode-chunk-payload :cookie-echo [_ ^ByteBuffer buf chunk]
+  (.put buf ^bytes (:cookie chunk)))
+
+(defmethod encode-chunk-payload :sack [_ ^ByteBuffer buf chunk]
+  (.putInt buf (unchecked-int (:cum-tsn-ack chunk)))
+  (.putInt buf (unchecked-int (:a-rwnd chunk)))
+  (.putShort buf (unchecked-short (count (:gap-blocks chunk))))
+  (.putShort buf (unchecked-short (count (:duplicate-tsns chunk))))
+  (doseq [[start end] (:gap-blocks chunk)]
+    (.putShort buf (unchecked-short start))
+    (.putShort buf (unchecked-short end)))
+  (doseq [dup (:duplicate-tsns chunk)]
+    (.putInt buf (unchecked-int dup))))
+
+(defmethod encode-chunk-payload :heartbeat [_ ^ByteBuffer buf chunk]
+  (encode-params buf (:params chunk)))
+
+(defmethod encode-chunk-payload :heartbeat-ack [_ ^ByteBuffer buf chunk]
+  (encode-params buf (:params chunk)))
+
+(defmethod encode-chunk-payload :default [_ ^ByteBuffer buf chunk]
+  (when (:body chunk)
+    (.put buf ^bytes (:body chunk))))
+
 (defn encode-chunk [^ByteBuffer buf chunk]
   (let [start-pos (.position buf)
         type-key (:type chunk)
@@ -286,56 +335,7 @@
     (.put buf (byte flags))
     (.putShort buf 0)
 
-    (case type-key
-      :data
-      (do
-        (.putInt buf (unchecked-int (:tsn chunk)))
-        (.putShort buf (unchecked-short (:stream-id chunk)))
-        (.putShort buf (unchecked-short (:seq-num chunk)))
-        (.putInt buf (unchecked-int (get protocols (:protocol chunk) (:protocol chunk))))
-        (.put buf ^bytes (:payload chunk)))
-
-      :init
-      (do
-        (.putInt buf (unchecked-int (:init-tag chunk)))
-        (.putInt buf (unchecked-int (:a-rwnd chunk)))
-        (.putShort buf (unchecked-short (:outbound-streams chunk)))
-        (.putShort buf (unchecked-short (:inbound-streams chunk)))
-        (.putInt buf (unchecked-int (:initial-tsn chunk)))
-        (encode-params buf (:params chunk)))
-
-      :init-ack
-      (do
-        (.putInt buf (unchecked-int (:init-tag chunk)))
-        (.putInt buf (unchecked-int (:a-rwnd chunk)))
-        (.putShort buf (unchecked-short (:outbound-streams chunk)))
-        (.putShort buf (unchecked-short (:inbound-streams chunk)))
-        (.putInt buf (unchecked-int (:initial-tsn chunk)))
-        (encode-params buf (:params chunk)))
-
-      :cookie-echo
-      (.put buf ^bytes (:cookie chunk))
-
-      :sack
-      (do
-        (.putInt buf (unchecked-int (:cum-tsn-ack chunk)))
-        (.putInt buf (unchecked-int (:a-rwnd chunk)))
-        (.putShort buf (unchecked-short (count (:gap-blocks chunk))))
-        (.putShort buf (unchecked-short (count (:duplicate-tsns chunk))))
-        (doseq [[start end] (:gap-blocks chunk)]
-          (.putShort buf (unchecked-short start))
-          (.putShort buf (unchecked-short end)))
-        (doseq [dup (:duplicate-tsns chunk)]
-          (.putInt buf (unchecked-int dup))))
-
-      :heartbeat
-      (encode-params buf (:params chunk))
-
-      :heartbeat-ack
-      (encode-params buf (:params chunk))
-
-      (when (:body chunk)
-        (.put buf ^bytes (:body chunk))))
+    (encode-chunk-payload type-key buf chunk)
 
     (let [end-pos (.position buf)
           len (- end-pos start-pos)


### PR DESCRIPTION
🎯 **What:** Extracted the large `case` statement handling specific chunk types in `encode-chunk` into a new `encode-chunk-payload` multimethod.
💡 **Why:** This drastically reduces the size and complexity of the `encode-chunk` function, making it easier to read and maintain. It also aligns the encoding logic with the pattern already established by `decode-chunk-payload` for decoding.
✅ **Verification:** Ran the full test suite (`clojure -M:test -m datachannel.test-runner`) including property-based tests for SCTP packet encoding/decoding. All tests passed successfully. Code review confirmed the refactoring preserves all existing functionality and correctly maintains type hints.
✨ **Result:** A cleaner, more modular `sctp.clj` where chunk payload encoding logic is decoupled from the base chunk header writing logic.

---
*PR created automatically by Jules for task [17169717964422459914](https://jules.google.com/task/17169717964422459914) started by @alpeware*