### PR TITLE
🧹 Extract make-binding-response from handle-packet

### DIFF
--- a/src/datachannel/stun.clj
+++ b/src/datachannel/stun.clj
@@ -176,6 +176,62 @@
              (recur (assoc attrs attr-type val-bytes)))
          {:type msg-type :length msg-len :cookie cookie :tx-id tx-id :attributes attrs}))))
 
+(defn make-binding-response [password tx-id ^InetSocketAddress peer-addr]
+  (let [resp-buf (ByteBuffer/allocate 1024)
+        _ (.order resp-buf ByteOrder/BIG_ENDIAN)]
+    ;; Header
+    (put-unsigned-short resp-buf 0x0101) ;; Success Response
+    (put-unsigned-short resp-buf 0)
+    (.putInt resp-buf magic-cookie)
+    (.put resp-buf tx-id)
+
+    ;; XOR-MAPPED-ADDRESS
+    (put-unsigned-short resp-buf ATTR_XOR_MAPPED_ADDRESS)
+    (put-unsigned-short resp-buf 8)
+    (.put resp-buf (byte 0))
+    (.put resp-buf (byte 1))
+    (put-unsigned-short resp-buf (bit-xor (.getPort peer-addr) (bit-shift-right magic-cookie 16)))
+    (let [addr-bytes (.getAddress (.getAddress peer-addr))
+          cookie-bytes (ByteBuffer/allocate 4)
+          _ (.putInt cookie-bytes magic-cookie)
+          _ (.flip cookie-bytes)
+          magic-bytes (.array cookie-bytes)
+          xor-addr (byte-array 4)]
+      (dotimes [i 4]
+        (aset xor-addr i (byte (bit-xor (aget addr-bytes i) (aget magic-bytes i)))))
+      (.put resp-buf xor-addr))
+
+    ;; MESSAGE-INTEGRITY
+    (let [len-before-mi (- (.position resp-buf) 20)
+          len-with-mi (+ len-before-mi 24)]
+      (.putShort resp-buf 2 (unchecked-short len-with-mi)))
+    (let [len-to-sign (.position resp-buf)
+          data-to-sign (byte-array len-to-sign)]
+      (.position resp-buf 0)
+      (.get resp-buf data-to-sign)
+      (.position resp-buf len-to-sign)
+      (let [hmac (compute-hmac-sha1 password data-to-sign)]
+        (put-unsigned-short resp-buf ATTR_MESSAGE_INTEGRITY)
+        (put-unsigned-short resp-buf 20)
+        (.put resp-buf hmac)))
+
+    ;; FINGERPRINT
+    (let [len-before-fp (- (.position resp-buf) 20)
+          total-len (+ len-before-fp 8)]
+      (.putShort resp-buf 2 (unchecked-short total-len)))
+    (let [len-to-crc (.position resp-buf)
+          data-to-crc (byte-array len-to-crc)]
+      (.position resp-buf 0)
+      (.get resp-buf data-to-crc)
+      (.position resp-buf len-to-crc)
+      (let [crc (compute-crc32 data-to-crc)]
+        (put-unsigned-short resp-buf ATTR_FINGERPRINT)
+        (put-unsigned-short resp-buf 4)
+        (.putInt resp-buf (unchecked-int crc))))
+
+    (.flip resp-buf)
+    resp-buf))
+
 (defn handle-packet [^ByteBuffer buf ^InetSocketAddress peer-addr connection]
   (try
     (let [start-pos (.position buf)
@@ -188,60 +244,7 @@
 
       (let [res (if (= msg-type 0x0001) ;; Binding Request
                   (if-let [password (:ice-pwd connection)]
-                    (let [resp-buf (ByteBuffer/allocate 1024)
-                          _ (.order resp-buf ByteOrder/BIG_ENDIAN)]
-                      ;; Header
-                      (put-unsigned-short resp-buf 0x0101) ;; Success Response
-                      (put-unsigned-short resp-buf 0)
-                      (.putInt resp-buf magic-cookie)
-                      (.put resp-buf tx-id)
-
-                      ;; XOR-MAPPED-ADDRESS
-                      (put-unsigned-short resp-buf ATTR_XOR_MAPPED_ADDRESS)
-                      (put-unsigned-short resp-buf 8)
-                      (.put resp-buf (byte 0))
-                      (.put resp-buf (byte 1))
-                      (put-unsigned-short resp-buf (bit-xor (.getPort peer-addr) (bit-shift-right magic-cookie 16)))
-                      (let [addr-bytes (.getAddress (.getAddress peer-addr))
-                            cookie-bytes (ByteBuffer/allocate 4)
-                            _ (.putInt cookie-bytes magic-cookie)
-                            _ (.flip cookie-bytes)
-                            magic-bytes (.array cookie-bytes)
-                            xor-addr (byte-array 4)]
-                        (dotimes [i 4]
-                          (aset xor-addr i (byte (bit-xor (aget addr-bytes i) (aget magic-bytes i)))))
-                        (.put resp-buf xor-addr))
-
-                      ;; MESSAGE-INTEGRITY
-                      (let [len-before-mi (- (.position resp-buf) 20)
-                            len-with-mi (+ len-before-mi 24)]
-                         (.putShort resp-buf 2 (unchecked-short len-with-mi)))
-                      (let [len-to-sign (.position resp-buf)
-                            data-to-sign (byte-array len-to-sign)]
-                         (.position resp-buf 0)
-                         (.get resp-buf data-to-sign)
-                         (.position resp-buf len-to-sign)
-                         (let [hmac (compute-hmac-sha1 password data-to-sign)]
-                            (put-unsigned-short resp-buf ATTR_MESSAGE_INTEGRITY)
-                            (put-unsigned-short resp-buf 20)
-                            (.put resp-buf hmac)))
-
-                      ;; FINGERPRINT
-                      (let [len-before-fp (- (.position resp-buf) 20)
-                            total-len (+ len-before-fp 8)]
-                         (.putShort resp-buf 2 (unchecked-short total-len)))
-                      (let [len-to-crc (.position resp-buf)
-                            data-to-crc (byte-array len-to-crc)]
-                         (.position resp-buf 0)
-                         (.get resp-buf data-to-crc)
-                         (.position resp-buf len-to-crc)
-                         (let [crc (compute-crc32 data-to-crc)]
-                            (put-unsigned-short resp-buf ATTR_FINGERPRINT)
-                            (put-unsigned-short resp-buf 4)
-                            (.putInt resp-buf (unchecked-int crc))))
-
-                      (.flip resp-buf)
-                      resp-buf)
+                    (make-binding-response password tx-id peer-addr)
                     nil)
                   nil)]
         (.position buf (min (.limit buf) (+ start-pos 20 msg-len)))


### PR DESCRIPTION
🎯 **What:** Extracted the inline buffer construction logic for STUN success responses from `handle-packet` into a dedicated `make-binding-response` function in `src/datachannel/stun.clj`.

💡 **Why:** The `handle-packet` function was becoming a "god function," containing a large block of code specifically dedicated to formulating and allocating the binding response buffers (XOR-MAPPED-ADDRESS, MESSAGE-INTEGRITY, FINGERPRINT). Moving this to a standalone function improves the readability of the packet dispatch logic and adheres to the single-responsibility principle.

✅ **Verification:** Verified by executing the full `datachannel.test-runner` test suite (using the local Clojure CLI), including both the `stun-test` unit tests and the `stun-webrtc-integration-test` suites. All 18 tests containing 47 assertions passed successfully without regressions.

✨ **Result:** `handle-packet` is now significantly shorter and easier to read, focusing solely on parsing the header and delegating the heavy lifting of response construction to `make-binding-response`.

---
*PR created automatically by Jules for task [5885951606399032496](https://jules.google.com/task/5885951606399032496) started by @alpeware*