### PR TITLE
🧹 Implement DTLSHandshakeWithReplicatedPacketsTest

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -4,7 +4,7 @@
 - [ ] [ClientAuth](https://github.com/twosigma/OpenJDK/blob/master/test/jdk/javax/net/ssl/DTLS/ClientAuth.java)
 - [ ] [DTLSBufferOverflowUnderflowTest](https://github.com/twosigma/OpenJDK/blob/master/test/jdk/javax/net/ssl/DTLS/DTLSBufferOverflowUnderflowTest.java)
 - [ ] [DTLSEnginesClosureTest](https://github.com/twosigma/OpenJDK/blob/master/test/jdk/javax/net/ssl/DTLS/DTLSEnginesClosureTest.java)
-- [ ] [DTLSHandshakeWithReplicatedPacketsTest](https://github.com/twosigma/OpenJDK/blob/master/test/jdk/javax/net/ssl/DTLS/DTLSHandshakeWithReplicatedPacketsTest.java)
+- [x] [DTLSHandshakeWithReplicatedPacketsTest](https://github.com/twosigma/OpenJDK/blob/master/test/jdk/javax/net/ssl/DTLS/DTLSHandshakeWithReplicatedPacketsTest.java)
 - [ ] [DTLSIncorrectAppDataTest](https://github.com/twosigma/OpenJDK/blob/master/test/jdk/javax/net/ssl/DTLS/DTLSIncorrectAppDataTest.java)
 - [ ] [DTLSMFLNTest](https://github.com/twosigma/OpenJDK/blob/master/test/jdk/javax/net/ssl/DTLS/DTLSMFLNTest.java)
 - [ ] [DTLSNamedGroups](https://github.com/twosigma/OpenJDK/blob/master/test/jdk/javax/net/ssl/DTLS/DTLSNamedGroups.java)

--- a/test/datachannel/handshake_test.clj
+++ b/test/datachannel/handshake_test.clj
@@ -88,6 +88,58 @@
       (is (= :success (run-handshake-loop client-engine server-engine)))
       (is (= "Hello Frag" (exchange-data client-engine server-engine "Hello Frag"))))))
 
+(defn- run-handshake-loop-with-replication [client-engine server-engine]
+  (let [client-out (ByteBuffer/allocate 65536)
+        server-out (ByteBuffer/allocate 65536)
+        client-in (ByteBuffer/allocate 65536)
+        server-in (ByteBuffer/allocate 65536)
+        max-loops 200]
+    (.flip client-in)
+    (.flip server-in)
+    (loop [i 0]
+      (if (> i max-loops)
+        (throw (Exception. "Handshake failed to complete in max loops"))
+        (let [client-status (.getHandshakeStatus client-engine)
+              server-status (.getHandshakeStatus server-engine)]
+          (if (and (or (= client-status SSLEngineResult$HandshakeStatus/NOT_HANDSHAKING)
+                       (= client-status SSLEngineResult$HandshakeStatus/FINISHED))
+                   (or (= server-status SSLEngineResult$HandshakeStatus/NOT_HANDSHAKING)
+                       (= server-status SSLEngineResult$HandshakeStatus/FINISHED))
+                   (not (.hasRemaining client-in))
+                   (not (.hasRemaining server-in)))
+            :success
+            (do
+              ;; Run client step
+              (let [res-c (dtls/handshake client-engine client-in client-out)
+                    packets-c (:packets res-c)]
+                (.compact server-in)
+                (doseq [p packets-c]
+                  ;; Replicate packet
+                  (.put server-in (ByteBuffer/wrap p))
+                  (.put server-in (ByteBuffer/wrap p)))
+                (.flip server-in))
+              ;; Run server step
+              (let [res-s (dtls/handshake server-engine server-in server-out)
+                    packets-s (:packets res-s)]
+                (.compact client-in)
+                (doseq [p packets-s]
+                  ;; Replicate packet
+                  (.put client-in (ByteBuffer/wrap p))
+                  (.put client-in (ByteBuffer/wrap p)))
+                (.flip client-in))
+              (recur (inc i)))))))))
+
+(deftest test-handshake-with-replicated-packets
+  (testing "DTLS handshake robustness against replicated packets"
+    (let [cert-data (dtls/generate-cert)
+          ctx (dtls/create-ssl-context (:cert cert-data) (:key cert-data))
+          client-engine (dtls/create-engine ctx true)
+          server-engine (dtls/create-engine ctx false)]
+      (.beginHandshake client-engine)
+      (.beginHandshake server-engine)
+      (is (= :success (run-handshake-loop-with-replication client-engine server-engine)))
+      (is (= "Hello Dup" (exchange-data client-engine server-engine "Hello Dup"))))))
+
 (deftest test-default-max-packet-size
   (testing "Verify default max packet size in created engine"
     (let [cert-data (dtls/generate-cert)


### PR DESCRIPTION
### 🎯 What
Implemented the `DTLSHandshakeWithReplicatedPacketsTest` in the DTLS handshake test suite.

### 💡 Why
To improve test coverage for DTLS edge cases and ensure the implementation correctly handles duplicate packets, which is common in unreliable networks.

### ✅ Verification
Ran `clojure -M:test -m datachannel.test-runner` and verified that all 19 tests, including the new `test-handshake-with-replicated-packets`, passed.

### ✨ Result
Increased confidence in the DTLS implementation's robustness and updated the project's testing checklist.

Fixes #68

---
*PR created automatically by Jules for task [1978183389813190640](https://jules.google.com/task/1978183389813190640) started by @alpeware*