### PR TITLE
🧹 [Implement DTLS Sequence Number Test]

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -13,7 +13,7 @@
 - [ ] [DTLSRehandshakeTest](https://github.com/twosigma/OpenJDK/blob/master/test/jdk/javax/net/ssl/DTLS/DTLSRehandshakeTest.java)
 - [ ] [DTLSRehandshakeWithCipherChangeTest](https://github.com/twosigma/OpenJDK/blob/master/test/jdk/javax/net/ssl/DTLS/DTLSRehandshakeWithCipherChangeTest.java)
 - [ ] [DTLSRehandshakeWithDataExTest](https://github.com/twosigma/OpenJDK/blob/master/test/jdk/javax/net/ssl/DTLS/DTLSRehandshakeWithDataExTest.java)
-- [ ] [DTLSSequenceNumberTest](https://github.com/twosigma/OpenJDK/blob/master/test/jdk/javax/net/ssl/DTLS/DTLSSequenceNumberTest.java)
+- [x] [DTLSSequenceNumberTest](https://github.com/twosigma/OpenJDK/blob/master/test/jdk/javax/net/ssl/DTLS/DTLSSequenceNumberTest.java)
 - [ ] [DTLSSignatureSchemes](https://github.com/twosigma/OpenJDK/blob/master/test/jdk/javax/net/ssl/DTLS/DTLSSignatureSchemes.java)
 - [ ] [DTLSUnsupportedCiphersTest](https://github.com/twosigma/OpenJDK/blob/master/test/jdk/javax/net/ssl/DTLS/DTLSUnsupportedCiphersTest.java)
 - [ ] [InvalidCookie](https://github.com/twosigma/OpenJDK/blob/master/test/jdk/javax/net/ssl/DTLS/InvalidCookie.java)

--- a/test/datachannel/handshake_test.clj
+++ b/test/datachannel/handshake_test.clj
@@ -2,7 +2,7 @@
   (:require [clojure.test :refer :all]
             [datachannel.dtls :as dtls])
   (:import [java.nio ByteBuffer]
-           [javax.net.ssl SSLEngine SSLEngineResult$HandshakeStatus]))
+           [javax.net.ssl SSLEngine SSLEngineResult$HandshakeStatus SSLEngineResult]))
 
 (defn- run-handshake-loop [client-engine server-engine]
   (let [client-out (ByteBuffer/allocate 65536)
@@ -164,3 +164,76 @@
           ctx (dtls/create-ssl-context (:cert cert-data) (:key cert-data))
           engine (dtls/create-engine ctx true)]
       (is (= dtls/DEFAULT-PACKET-SIZE (.getMaximumPacketSize (.getSSLParameters engine)))))))
+
+(deftest test-sequence-number
+  (testing "DTLS Sequence Number support in application data exchange"
+    (let [cert-data (dtls/generate-cert)
+          ctx (dtls/create-ssl-context (:cert cert-data) (:key cert-data))
+          client-engine (dtls/create-engine ctx true)
+          server-engine (dtls/create-engine ctx false)]
+      (.beginHandshake client-engine)
+      (.beginHandshake server-engine)
+      (is (= :success (run-handshake-loop client-engine server-engine)))
+
+      (let [big-message "Very very big message. One two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty."
+            big-message-bytes (.getBytes big-message)
+            pieces-number 15
+            symbols-in-a-message (quot (alength big-message-bytes) pieces-number)
+            symbols-in-the-last-message (+ symbols-in-a-message (rem (alength big-message-bytes) pieces-number))
+
+            ;; Create pieces
+            sent-messages
+            (vec (for [i (range pieces-number)]
+                   (if (= i (dec pieces-number))
+                     (ByteBuffer/wrap big-message-bytes (* i symbols-in-a-message) symbols-in-the-last-message)
+                     (ByteBuffer/wrap big-message-bytes (* i symbols-in-a-message) symbols-in-a-message))))
+
+            ;; Wrap messages in direct order
+            wrapped-results
+            (loop [i 0
+                   prev-seq -1
+                   results []]
+              (if (< i pieces-number)
+                (let [in-buf (sent-messages i)
+                      out-buf (ByteBuffer/allocate (.getPacketBufferSize (.getSession client-engine)))
+                      result (.wrap client-engine in-buf out-buf)
+                      seq-num (.sequenceNumber result)]
+                  (is (> seq-num prev-seq) "Sequence number should be monotonically increasing")
+                  (.flip out-buf)
+                  (let [arr (byte-array (.remaining out-buf))]
+                    (.get out-buf arr)
+                    (recur (inc i) seq-num (conj results {:seq-num seq-num :bytes arr}))))
+                results))
+
+            ;; Unwrap messages in random order
+            receiving-sequence (shuffle (range pieces-number))
+            recv-map
+            (loop [i 0
+                   m (sorted-map)]
+              (if (< i pieces-number)
+                (let [recv-now (nth receiving-sequence i)
+                      wrapped-bytes (:bytes (wrapped-results recv-now))
+                      in-buf (ByteBuffer/wrap wrapped-bytes)
+                      out-buf (ByteBuffer/allocate (.getApplicationBufferSize (.getSession server-engine)))
+                      result (.unwrap server-engine in-buf out-buf)
+                      seq-num (.sequenceNumber result)]
+                  (.flip out-buf)
+                  (let [arr (byte-array (.remaining out-buf))]
+                    (.get out-buf arr)
+                    (recur (inc i) (assoc m seq-num arr))))
+                m))]
+
+        ;; Reconstruct and verify
+        (is (= pieces-number (count recv-map)))
+
+        (let [reconstructed-bytes
+              (let [total-len (reduce + (map alength (vals recv-map)))
+                    res (byte-array total-len)]
+                (loop [chunks (vals recv-map)
+                       offset 0]
+                  (when-let [chunk (first chunks)]
+                    (System/arraycopy chunk 0 res offset (alength chunk))
+                    (recur (rest chunks) (+ offset (alength chunk)))))
+                res)
+              reconstructed-msg (String. reconstructed-bytes)]
+          (is (= big-message reconstructed-msg)))))))


### PR DESCRIPTION
🎯 What
Implemented `test-sequence-number` inside `datachannel.handshake-test`. This test accurately replicates the OpenJDK `DTLSSequenceNumberTest`, establishing that the library correctly implements SSLEngine sequence numbers and that payloads mapped securely out-of-order can be successfully reordered via `.sequenceNumber()`. Marked `DTLSSequenceNumberTest` as complete in `TESTING.md`.

💡 Why
This expands test coverage against edge-cases for out-of-order UDP packet handling to ensure robust data reliability over Datagram connections, which completes another missing test box in `TESTING.md`.

✅ Verification
Ran the `clojure -M:test -e "(require 'datachannel.handshake-test) (clojure.test/run-tests 'datachannel.handshake-test)"` suite with the new test as well as `clojure -M:test -m datachannel.test-runner` for the entire suite, all passing without faults.

✨ Result
Added robust functional testing guaranteeing correct unwrap sequencing via DTLS.

---
*PR created automatically by Jules for task [11689166151112091324](https://jules.google.com/task/11689166151112091324) started by @alpeware*