### PR TITLE
🧹 Implement DTLS Reordered test case

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -20,7 +20,7 @@
 - [ ] [InvalidRecords](https://github.com/twosigma/OpenJDK/blob/master/test/jdk/javax/net/ssl/DTLS/InvalidRecords.java)
 - [ ] [NoMacInitialClientHello](https://github.com/twosigma/OpenJDK/blob/master/test/jdk/javax/net/ssl/DTLS/NoMacInitialClientHello.java)
 - [ ] [PacketLossRetransmission](https://github.com/twosigma/OpenJDK/blob/master/test/jdk/javax/net/ssl/DTLS/PacketLossRetransmission.java)
-- [ ] [Reordered](https://github.com/twosigma/OpenJDK/blob/master/test/jdk/javax/net/ssl/DTLS/Reordered.java)
+- [x] [Reordered](https://github.com/twosigma/OpenJDK/blob/master/test/jdk/javax/net/ssl/DTLS/Reordered.java)
 - [ ] [RespondToRetransmit](https://github.com/twosigma/OpenJDK/blob/master/test/jdk/javax/net/ssl/DTLS/RespondToRetransmit.java)
 - [ ] [Retransmission](https://github.com/twosigma/OpenJDK/blob/master/test/jdk/javax/net/ssl/DTLS/Retransmission.java)
 - [ ] [WeakCipherSuite](https://github.com/twosigma/OpenJDK/blob/master/test/jdk/javax/net/ssl/DTLS/WeakCipherSuite.java)

--- a/test/datachannel/handshake_test.clj
+++ b/test/datachannel/handshake_test.clj
@@ -140,6 +140,56 @@
       (is (= :success (run-handshake-loop-with-replication client-engine server-engine)))
       (is (= "Hello Dup" (exchange-data client-engine server-engine "Hello Dup"))))))
 
+(defn- run-handshake-loop-with-reordering [client-engine server-engine]
+  (let [client-out (ByteBuffer/allocate 65536)
+        server-out (ByteBuffer/allocate 65536)
+        client-in (ByteBuffer/allocate 65536)
+        server-in (ByteBuffer/allocate 65536)
+        max-loops 200]
+    (.flip client-in)
+    (.flip server-in)
+    (loop [i 0 reordered-server false]
+      (if (> i max-loops)
+        (throw (Exception. "Handshake failed to complete in max loops"))
+        (let [client-status (.getHandshakeStatus client-engine)
+              server-status (.getHandshakeStatus server-engine)]
+          (if (and (or (= client-status SSLEngineResult$HandshakeStatus/NOT_HANDSHAKING)
+                       (= client-status SSLEngineResult$HandshakeStatus/FINISHED))
+                   (or (= server-status SSLEngineResult$HandshakeStatus/NOT_HANDSHAKING)
+                       (= server-status SSLEngineResult$HandshakeStatus/FINISHED))
+                   (not (.hasRemaining client-in))
+                   (not (.hasRemaining server-in)))
+            :success
+            (do
+              ;; Run client step
+              (let [res-c (dtls/handshake client-engine client-in client-out)
+                    packets-c (:packets res-c)]
+                (.compact server-in)
+                (doseq [p packets-c]
+                  (.put server-in (ByteBuffer/wrap p)))
+                (.flip server-in))
+              ;; Run server step
+              (let [res-s (dtls/handshake server-engine server-in server-out)
+                    packets-s (:packets res-s)
+                    do-reorder (and (not reordered-server) (> (count packets-s) 1))
+                    ps (if do-reorder (reverse packets-s) packets-s)]
+                (.compact client-in)
+                (doseq [p ps]
+                  (.put client-in (ByteBuffer/wrap p)))
+                (.flip client-in)
+                (recur (inc i) (or reordered-server do-reorder))))))))))
+
+(deftest test-handshake-with-reordered-packets
+  (testing "DTLS handshake robustness against reordered packets"
+    (let [cert-data (dtls/generate-cert)
+          ctx (dtls/create-ssl-context (:cert cert-data) (:key cert-data))
+          client-engine (dtls/create-engine ctx true)
+          server-engine (dtls/create-engine ctx false)]
+      (.beginHandshake client-engine)
+      (.beginHandshake server-engine)
+      (is (= :success (run-handshake-loop-with-reordering client-engine server-engine)))
+      (is (= "Hello Reordered" (exchange-data client-engine server-engine "Hello Reordered"))))))
+
 
 (deftest test-client-auth
   (testing "DTLS client authentication requirement"


### PR DESCRIPTION
🎯 What
Implemented the `Reordered` DTLS test from the `TESTING.md` checklist.
Added `run-handshake-loop-with-reordering` helper function and `test-handshake-with-reordered-packets` test to `datachannel.handshake-test`.

💡 Why
To ensure our DTLS implementation correctly handles packets that are received out of order, which is a fundamental requirement for UDP-based protocols. This helps achieve feature parity with the OpenJDK reference test suite.

✅ Verification
Ran `clojure -M:test -e "(require 'datachannel.handshake-test) (clojure.test/run-tests 'datachannel.handshake-test)"` and the entire test suite `clojure -M:test -m datachannel.test-runner` to verify that the reordering logic works correctly and does not break existing code.

✨ Result
The `Reordered` test case is now checked off in `TESTING.md` and passes successfully.

---
*PR created automatically by Jules for task [890015580235725681](https://jules.google.com/task/890015580235725681) started by @alpeware*