### PR TITLE
🧹 Improve SCTP robustness with TSN wraparound fix and new test cases

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -24,3 +24,11 @@
 - [ ] [RespondToRetransmit](https://github.com/twosigma/OpenJDK/blob/master/test/jdk/javax/net/ssl/DTLS/RespondToRetransmit.java)
 - [ ] [Retransmission](https://github.com/twosigma/OpenJDK/blob/master/test/jdk/javax/net/ssl/DTLS/Retransmission.java)
 - [ ] [WeakCipherSuite](https://github.com/twosigma/OpenJDK/blob/master/test/jdk/javax/net/ssl/DTLS/WeakCipherSuite.java)
+
+# SCTP
+
+- [ ] [Tail Loss Probing (TLP)](https://github.com/webrtc/dcsctp/blob/main/src/tx/retransmission_queue.rs)
+- [x] [Unordered Head-of-Line Blocking](https://github.com/webrtc/dcsctp/blob/main/src/rx/reassembly_queue.rs)
+- [x] [TSN Wraparound](https://github.com/webrtc/dcsctp/blob/main/src/tx/retransmission_queue.rs)
+- [ ] [Delayed SACKs](https://github.com/webrtc/dcsctp/blob/main/src/tx/retransmission_timeout.rs)
+- [ ] [Full Socket State Machine](https://github.com/webrtc/dcsctp/blob/main/src/socket/socket_tests.rs)

--- a/src/datachannel/core.clj
+++ b/src/datachannel/core.clj
@@ -34,7 +34,8 @@
               tsn (:tsn chunk)]
           ;; Update remote TSN and send SACK
           (swap! state (fn [s]
-                         (if (> tsn (:remote-tsn s))
+                         ;; Serial number arithmetic for 32-bit unsigned TSN
+                         (if (pos? (unchecked-int (unchecked-subtract (unchecked-int tsn) (unchecked-int (:remote-tsn s)))))
                            (assoc s :remote-tsn tsn)
                            s)))
           (let [sack-packet {:src-port (:dst-port packet)

--- a/test/datachannel/sctp_robustness_test.clj
+++ b/test/datachannel/sctp_robustness_test.clj
@@ -1,0 +1,57 @@
+(ns datachannel.sctp-robustness-test
+  (:require [clojure.test :refer :all]
+            [datachannel.core :as core]))
+
+(deftest tsn-wraparound-test
+  (testing "TSN wraparound handling"
+    (let [state (atom {:remote-tsn 4294967295 :remote-ver-tag 123})
+          connection {:state state
+                      :sctp-out (java.util.concurrent.LinkedBlockingQueue.)
+                      :on-message (atom nil)
+                      :on-data (atom nil)}
+          ;; Accessing private handle-sctp-packet for testing
+          handle-sctp-packet #'core/handle-sctp-packet
+          packet {:src-port 5000 :dst-port 5000
+                  :chunks [{:type :data :tsn 0 :protocol :webrtc/string :payload (byte-array 0)}]}]
+
+      (handle-sctp-packet packet connection)
+      (is (= 0 (:remote-tsn @state)) "TSN 0 should be considered newer than 4294967295")
+
+      (handle-sctp-packet {:src-port 5000 :dst-port 5000
+                           :chunks [{:type :data :tsn 10 :protocol :webrtc/string :payload (byte-array 0)}]}
+                          connection)
+      (is (= 10 (:remote-tsn @state)) "TSN 10 should be considered newer than 0")
+
+      (handle-sctp-packet {:src-port 5000 :dst-port 5000
+                           :chunks [{:type :data :tsn 5 :protocol :webrtc/string :payload (byte-array 0)}]}
+                          connection)
+      (is (= 10 (:remote-tsn @state)) "Old TSN 5 should NOT update remote-tsn (still 10)"))))
+
+(deftest unordered-delivery-test
+  (testing "Unordered delivery Head-of-Line blocking"
+    (let [received (atom [])
+          state (atom {:remote-tsn 0 :remote-ver-tag 123})
+          connection {:state state
+                      :sctp-out (java.util.concurrent.LinkedBlockingQueue.)
+                      :on-message (atom (fn [payload] (swap! received conj (String. ^bytes payload))))
+                      :on-data (atom nil)}
+          handle-sctp-packet #'core/handle-sctp-packet]
+
+      ;; In unordered delivery, if we receive TSN 2 before TSN 1, it should still be delivered immediately.
+      ;; Note: Current implementation in core.clj delivers EVERY data chunk immediately
+      ;; as long as it's not a duplicate (actually it delivers everything right now,
+      ;; it just updates remote-tsn if it's newer).
+
+      (handle-sctp-packet {:src-port 5000 :dst-port 5000
+                           :chunks [{:type :data :tsn 2 :protocol :webrtc/string
+                                     :payload (.getBytes "Second") :unordered true}]}
+                          connection)
+
+      (is (= ["Second"] @received) "TSN 2 should be delivered even if TSN 1 is missing (unordered)")
+
+      (handle-sctp-packet {:src-port 5000 :dst-port 5000
+                           :chunks [{:type :data :tsn 1 :protocol :webrtc/string
+                                     :payload (.getBytes "First") :unordered true}]}
+                          connection)
+
+      (is (= ["Second" "First"] @received) "TSN 1 should be delivered when it arrives"))))

--- a/test/datachannel/test_runner.clj
+++ b/test/datachannel/test_runner.clj
@@ -9,7 +9,8 @@
             [datachannel.stun-integration-test]
             [datachannel.stun-webrtc-integration-test]
             [datachannel.webrtc-integration-test]
-            [datachannel.webrtc-extended-test]))
+            [datachannel.webrtc-extended-test]
+            [datachannel.sctp-robustness-test]))
 
 (defn -main []
   (let [{:keys [fail error]} (test/run-tests 'datachannel.sctp-test
@@ -21,7 +22,8 @@
                                              'datachannel.stun-integration-test
                                              'datachannel.stun-webrtc-integration-test
                                              'datachannel.webrtc-integration-test
-                                             'datachannel.webrtc-extended-test)]
+                                             'datachannel.webrtc-extended-test
+                                             'datachannel.sctp-robustness-test)]
     (if (> (+ fail error) 0)
       (System/exit 1)
       (System/exit 0))))


### PR DESCRIPTION
🎯 What:
- Updated TESTING.md with a new SCTP section documenting critical edge cases (TLP, HoL blocking, TSN wraparound, Delayed SACKs, Socket State Machine) with links to dcsctp reference implementation.
- Fixed a bug in src/datachannel/core.clj where TSN comparison did not account for 32-bit unsigned integer wraparound.
- Implemented test/datachannel/sctp_robustness_test.clj to verify TSN wraparound logic and unordered delivery (lack of HoL blocking).
- Integrated the new tests into datachannel.test-runner.

💡 Why:
- SCTP TSNs are 32-bit unsigned integers that wrap around. The previous > comparison would fail when the TSN wrapped from 4,294,967,295 to 0.
- Documenting and testing these edge cases ensures the library is robust enough for WebRTC production use, following best practices from the dcsctp reference implementation.

✅ Verification:
- Created and ran datachannel.sctp-robustness-test, which specifically targets TSN wraparound and unordered delivery.
- Ran the full test suite using clojure -M:test -m datachannel.test-runner, ensuring no regressions in existing STUN, DTLS, or WebRTC integration tests.
- Manually verified the logic fix in core.clj using serial arithmetic.

✨ Result:
- The library now correctly handles TSN wraparound, preventing connection stalls or dropped data when sequence numbers cross the 32-bit boundary.
- Improved test coverage for SCTP robustness.
- Clear documentation in TESTING.md for remaining SCTP edge cases to be addressed.

Fixes #75

---
*PR created automatically by Jules for task [15293160959651693038](https://jules.google.com/task/15293160959651693038) started by @alpeware*