### PR TITLE
🧹 [Implement CipherSuite test for DTLS]

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -1,6 +1,6 @@
 # DTLS
 
-- [ ] [CipherSuite](https://github.com/twosigma/OpenJDK/blob/master/test/jdk/javax/net/ssl/DTLS/CipherSuite.java)
+- [x] [CipherSuite](https://github.com/twosigma/OpenJDK/blob/master/test/jdk/javax/net/ssl/DTLS/CipherSuite.java)
 - [x] [ClientAuth](https://github.com/twosigma/OpenJDK/blob/master/test/jdk/javax/net/ssl/DTLS/ClientAuth.java)
 - [ ] [DTLSBufferOverflowUnderflowTest](https://github.com/twosigma/OpenJDK/blob/master/test/jdk/javax/net/ssl/DTLS/DTLSBufferOverflowUnderflowTest.java)
 - [ ] [DTLSEnginesClosureTest](https://github.com/twosigma/OpenJDK/blob/master/test/jdk/javax/net/ssl/DTLS/DTLSEnginesClosureTest.java)

--- a/test/datachannel/handshake_test.clj
+++ b/test/datachannel/handshake_test.clj
@@ -191,6 +191,40 @@
       (is (= "Hello Reordered" (exchange-data client-engine server-engine "Hello Reordered"))))))
 
 
+(deftest test-cipher-suite
+  (testing "DTLS connection with specific cipher suites"
+    (let [cert-data (dtls/generate-cert)
+          ctx (dtls/create-ssl-context (:cert cert-data) (:key cert-data))
+          ;; Get a list of supported cipher suites from a dummy engine
+          dummy-engine (dtls/create-engine ctx true)
+          supported-suites (.getSupportedCipherSuites dummy-engine)
+          ;; Filter for typical DTLS 1.2 suites and avoid those that might require
+          ;; specific certificate types we don't generate (like ECDSA or DSS) or are weak/disabled
+          test-suites (filter #(and (.startsWith ^String % "TLS_")
+                                    (not (.contains ^String % "_RC4_"))
+                                    (not (.contains ^String % "_NULL_"))
+                                    (not (.contains ^String % "_anon_"))
+                                    (not (.contains ^String % "_DES_"))
+                                    ;; Since we use a single self-signed cert (likely RSA),
+                                    ;; we restrict to suites that work with it.
+                                    (or (.contains ^String % "_RSA_")))
+                              supported-suites)]
+      (doseq [suite test-suites]
+        (let [client-engine (dtls/create-engine ctx true)
+              server-engine (dtls/create-engine ctx false)]
+          ;; Set the client to only support this specific suite
+          (.setEnabledCipherSuites client-engine (into-array String [suite]))
+
+          ;; Ensure server supports it
+          (let [server-suites (into #{} (.getEnabledCipherSuites server-engine))]
+            (when (server-suites suite)
+              (.beginHandshake client-engine)
+              (.beginHandshake server-engine)
+              (is (= :success (run-handshake-loop client-engine server-engine))
+                  (str "Handshake failed for cipher suite: " suite))
+              (is (= "Cipher OK" (exchange-data client-engine server-engine "Cipher OK"))
+                  (str "Data exchange failed for cipher suite: " suite)))))))))
+
 (deftest test-client-auth
   (testing "DTLS client authentication requirement"
     (let [cert-data (dtls/generate-cert)


### PR DESCRIPTION
🎯 What
Implemented the missing `CipherSuite` DTLS test from `TESTING.md`. The new test `test-cipher-suite` iterates through valid, supported cipher suites on the JVM, configures the client to use them exclusively, and ensures a full DTLS handshake and data exchange can be performed with the server.

💡 Why
To ensure the DTLS implementation gracefully handles various cipher suite negotiations and matches the coverage of the reference OpenJDK test suite.

✅ Verification
Ran `clojure -M:test -e "(require 'datachannel.handshake-test) (clojure.test/run-tests 'datachannel.handshake-test)"` and the full test suite (`clojure -M:test -m datachannel.test-runner`) locally. All tests passed.

✨ Result
Increased test coverage for DTLS cipher suite negotiation. Checked off `CipherSuite` in `TESTING.md`.

---
*PR created automatically by Jules for task [12090452898229222293](https://jules.google.com/task/12090452898229222293) started by @alpeware*