### PR TITLE
Add NoMacInitialClientHello test to DTLS suite

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -18,7 +18,7 @@
 - [ ] [DTLSUnsupportedCiphersTest](https://github.com/twosigma/OpenJDK/blob/master/test/jdk/javax/net/ssl/DTLS/DTLSUnsupportedCiphersTest.java)
 - [x] [InvalidCookie](https://github.com/twosigma/OpenJDK/blob/master/test/jdk/javax/net/ssl/DTLS/InvalidCookie.java)
 - [ ] [InvalidRecords](https://github.com/twosigma/OpenJDK/blob/master/test/jdk/javax/net/ssl/DTLS/InvalidRecords.java)
-- [ ] [NoMacInitialClientHello](https://github.com/twosigma/OpenJDK/blob/master/test/jdk/javax/net/ssl/DTLS/NoMacInitialClientHello.java)
+- [x] [NoMacInitialClientHello](https://github.com/twosigma/OpenJDK/blob/master/test/jdk/javax/net/ssl/DTLS/NoMacInitialClientHello.java)
 - [x] [PacketLossRetransmission](https://github.com/twosigma/OpenJDK/blob/master/test/jdk/javax/net/ssl/DTLS/PacketLossRetransmission.java)
 - [x] [Reordered](https://github.com/twosigma/OpenJDK/blob/master/test/jdk/javax/net/ssl/DTLS/Reordered.java)
 - [ ] [RespondToRetransmit](https://github.com/twosigma/OpenJDK/blob/master/test/jdk/javax/net/ssl/DTLS/RespondToRetransmit.java)

--- a/test/datachannel/handshake_test.clj
+++ b/test/datachannel/handshake_test.clj
@@ -511,6 +511,109 @@
       (is (= :success (run-handshake-loop-invalid-cookie client-engine server-engine)))
       (is (= "Hello after invalid cookie" (exchange-data client-engine server-engine "Hello after invalid cookie"))))))
 
+(defn- run-handshake-loop-invalid-initial-client-hello [client-engine server-engine]
+  (let [client-out (ByteBuffer/allocate 65536)
+        server-out (ByteBuffer/allocate 65536)
+        client-in (ByteBuffer/allocate 65536)
+        server-in (ByteBuffer/allocate 65536)
+        max-loops 200]
+    (.flip client-in)
+    (.flip server-in)
+    (loop [i 0
+           invalidated-hello false]
+      (if (> i max-loops)
+        (throw (Exception. "Handshake failed to complete in max loops"))
+        (let [client-status (.getHandshakeStatus client-engine)
+              server-status (.getHandshakeStatus server-engine)]
+          (if (and (or (= client-status SSLEngineResult$HandshakeStatus/NOT_HANDSHAKING)
+                       (= client-status SSLEngineResult$HandshakeStatus/FINISHED))
+                   (or (= server-status SSLEngineResult$HandshakeStatus/NOT_HANDSHAKING)
+                       (= server-status SSLEngineResult$HandshakeStatus/FINISHED))
+                   (not (.hasRemaining client-in))
+                   (not (.hasRemaining server-in)))
+            :success
+            (let [res-c (dtls/handshake client-engine client-in client-out)
+                  packets-c (:packets res-c)
+
+                  ;; Mutate the first ClientHello
+                  mutated-packets-c
+                  (map (fn [^bytes p]
+                         (if (and (not invalidated-hello)
+                                  (>= (alength p) 60)
+                                  (= (aget p 0) (unchecked-byte 0x16))
+                                  (= (aget p 13) (unchecked-byte 0x01)))
+                           (let [mutated (byte-array (alength p))]
+                             (System/arraycopy p 0 mutated 0 (alength p))
+                             (let [last-idx (dec (alength mutated))
+                                   last-byte (aget mutated last-idx)]
+                               (if (= last-byte (unchecked-byte 0xFF))
+                                 (aset mutated last-idx (unchecked-byte 0xFE))
+                                 (aset mutated last-idx (unchecked-byte 0xFF))))
+                             mutated)
+                           p))
+                       packets-c)
+
+                  has-mutated (some #(and (>= (alength %) 60)
+                                          (= (aget % 0) (unchecked-byte 0x16))
+                                          (= (aget % 13) (unchecked-byte 0x01)))
+                                    packets-c)
+                  new-invalidated-hello (or invalidated-hello has-mutated)]
+
+              (.compact server-in)
+              (doseq [p mutated-packets-c]
+                (.put server-in (ByteBuffer/wrap p)))
+              (.flip server-in)
+
+              (let [res-s (dtls/handshake server-engine server-in server-out)
+                    packets-s (:packets res-s)]
+                (.compact client-in)
+                (doseq [p packets-s]
+                  (.put client-in (ByteBuffer/wrap p)))
+                (.flip client-in)
+
+                (let [c-status-after (.getHandshakeStatus client-engine)
+                      s-status-after (.getHandshakeStatus server-engine)
+                      timeout-c? (and (not (.hasRemaining client-in))
+                                      (not (.hasRemaining server-in))
+                                      (= c-status-after SSLEngineResult$HandshakeStatus/NEED_UNWRAP))
+                      timeout-s? (and (not (.hasRemaining client-in))
+                                      (not (.hasRemaining server-in))
+                                      (= s-status-after SSLEngineResult$HandshakeStatus/NEED_UNWRAP))]
+                  (when (or timeout-c? timeout-s?)
+                    (Thread/sleep 1000)
+                    (when timeout-c?
+                      (.clear client-out)
+                      (let [res (.wrap client-engine (ByteBuffer/allocate 0) client-out)]
+                        (.flip client-out)
+                        (when (> (.remaining client-out) 0)
+                          (let [arr (byte-array (.remaining client-out))]
+                            (.get client-out arr)
+                            (.compact server-in)
+                            (.put server-in (ByteBuffer/wrap arr))
+                            (.flip server-in)))))
+                    (when timeout-s?
+                      (.clear server-out)
+                      (let [res (.wrap server-engine (ByteBuffer/allocate 0) server-out)]
+                        (.flip server-out)
+                        (when (> (.remaining server-out) 0)
+                          (let [arr (byte-array (.remaining server-out))]
+                            (.get server-out arr)
+                            (.compact client-in)
+                            (.put client-in (ByteBuffer/wrap arr))
+                            (.flip client-in))))))
+                  (recur (inc i) new-invalidated-hello))))))))))
+
+(deftest test-no-mac-initial-client-hello
+  (testing "DTLS server discards invalid initial ClientHello silently"
+    (let [cert-data (dtls/generate-cert)
+          ctx (dtls/create-ssl-context (:cert cert-data) (:key cert-data))
+          client-engine (dtls/create-engine ctx true)
+          server-engine (dtls/create-engine ctx false)]
+      (.beginHandshake client-engine)
+      (.beginHandshake server-engine)
+      (is (= :success (run-handshake-loop-invalid-initial-client-hello client-engine server-engine)))
+      (is (= "Hello after invalid initial" (exchange-data client-engine server-engine "Hello after invalid initial"))))))
+
 (deftest test-packet-loss-retransmission
   (testing "DTLS handshake recovers from packet loss via timeout and retransmission"
     (let [cert-data (dtls/generate-cert)


### PR DESCRIPTION
Added the missing NoMacInitialClientHello test case for DTLS. This test simulates an invalid/corrupted initial ClientHello message from the client (by mutating the last byte of the packet payload) and verifies that the DTLS server properly discards the invalid record silently, causing the client to timeout and retransmit to successfully complete the handshake. Checked it off the list in TESTING.md.

---
*PR created automatically by Jules for task [7433486837428393095](https://jules.google.com/task/7433486837428393095) started by @alpeware*