### PR TITLE
🧹 [add InvalidRecords test case]

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -17,7 +17,7 @@
 - [ ] [DTLSSignatureSchemes](https://github.com/twosigma/OpenJDK/blob/master/test/jdk/javax/net/ssl/DTLS/DTLSSignatureSchemes.java)
 - [ ] [DTLSUnsupportedCiphersTest](https://github.com/twosigma/OpenJDK/blob/master/test/jdk/javax/net/ssl/DTLS/DTLSUnsupportedCiphersTest.java)
 - [x] [InvalidCookie](https://github.com/twosigma/OpenJDK/blob/master/test/jdk/javax/net/ssl/DTLS/InvalidCookie.java)
-- [ ] [InvalidRecords](https://github.com/twosigma/OpenJDK/blob/master/test/jdk/javax/net/ssl/DTLS/InvalidRecords.java)
+- [x] [InvalidRecords](https://github.com/twosigma/OpenJDK/blob/master/test/jdk/javax/net/ssl/DTLS/InvalidRecords.java)
 - [ ] [NoMacInitialClientHello](https://github.com/twosigma/OpenJDK/blob/master/test/jdk/javax/net/ssl/DTLS/NoMacInitialClientHello.java)
 - [x] [PacketLossRetransmission](https://github.com/twosigma/OpenJDK/blob/master/test/jdk/javax/net/ssl/DTLS/PacketLossRetransmission.java)
 - [x] [Reordered](https://github.com/twosigma/OpenJDK/blob/master/test/jdk/javax/net/ssl/DTLS/Reordered.java)

--- a/test/datachannel/handshake_test.clj
+++ b/test/datachannel/handshake_test.clj
@@ -511,6 +511,78 @@
       (is (= :success (run-handshake-loop-invalid-cookie client-engine server-engine)))
       (is (= "Hello after invalid cookie" (exchange-data client-engine server-engine "Hello after invalid cookie"))))))
 
+(defn- run-handshake-loop-invalid-records [client-engine server-engine]
+  (let [client-out (ByteBuffer/allocate 65536)
+        server-out (ByteBuffer/allocate 65536)
+        client-in (ByteBuffer/allocate 65536)
+        server-in (ByteBuffer/allocate 65536)
+        max-loops 100]
+    (.flip client-in)
+    (.flip server-in)
+    (loop [i 0
+           invalidated-record false]
+      (if (> i max-loops)
+        (throw (Exception. "Handshake failed to complete in max loops"))
+        (let [client-status (.getHandshakeStatus client-engine)
+              server-status (.getHandshakeStatus server-engine)]
+          (if (and (or (= client-status SSLEngineResult$HandshakeStatus/NOT_HANDSHAKING)
+                       (= client-status SSLEngineResult$HandshakeStatus/FINISHED))
+                   (or (= server-status SSLEngineResult$HandshakeStatus/NOT_HANDSHAKING)
+                       (= server-status SSLEngineResult$HandshakeStatus/FINISHED))
+                   (not (.hasRemaining client-in))
+                   (not (.hasRemaining server-in)))
+            :success
+            (let [res-c (try (dtls/handshake client-engine client-in client-out)
+                             (catch javax.net.ssl.SSLException e
+                               :ssl-exception))
+                  packets-c (if (= res-c :ssl-exception) [] (:packets res-c))]
+              (if (= res-c :ssl-exception)
+                :failed
+                (do
+                  (.compact server-in)
+                  (let [new-invalidated
+                        (reduce (fn [invalidated p]
+                                  (let [is-client-hello (and (>= (alength p) 60)
+                                                             (= (aget p 0) (unchecked-byte 0x16))
+                                                             (= (aget p 13) (unchecked-byte 0x01))
+                                                             (= (aget p 59) (unchecked-byte 0x00))
+                                                             (pos? (aget p 60)))
+                                        should-mutate (and is-client-hello (not invalidated))]
+                                    (when should-mutate
+                                      (let [last-idx (dec (alength p))
+                                            last-byte (aget p last-idx)]
+                                        (aset p last-idx (if (= last-byte (unchecked-byte 0xFF))
+                                                           (unchecked-byte 0xFE)
+                                                           (unchecked-byte 0xFF)))))
+                                    (.put server-in (ByteBuffer/wrap p))
+                                    (or invalidated should-mutate)))
+                                invalidated-record
+                                packets-c)]
+                    (.flip server-in)
+                    (let [res-s (try (dtls/handshake server-engine server-in server-out)
+                                     (catch javax.net.ssl.SSLException e
+                                       :ssl-exception))
+                          packets-s (if (= res-s :ssl-exception) [] (:packets res-s))]
+                      (if (= res-s :ssl-exception)
+                        :failed
+                        (do
+                          (.compact client-in)
+                          (doseq [p packets-s]
+                            (.put client-in (ByteBuffer/wrap p)))
+                          (.flip client-in)
+                          (recur (inc i) new-invalidated))))))))))))))
+
+(deftest test-invalid-records
+  (testing "DTLS handshake with modified ClientHello fails hash verification"
+    (let [cert-data (dtls/generate-cert)
+          ctx (dtls/create-ssl-context (:cert cert-data) (:key cert-data))
+          client-engine (dtls/create-engine ctx true)
+          server-engine (dtls/create-engine ctx false)]
+      (.beginHandshake client-engine)
+      (.beginHandshake server-engine)
+      (is (= :failed (run-handshake-loop-invalid-records client-engine server-engine))))))
+
+
 (deftest test-packet-loss-retransmission
   (testing "DTLS handshake recovers from packet loss via timeout and retransmission"
     (let [cert-data (dtls/generate-cert)


### PR DESCRIPTION
🎯 What
Added the `InvalidRecords` test case from the OpenJDK DTLS test suite to verify that modifying the `ClientHello` message during handshake properly fails the hash verification process.

💡 Why
To ensure the DTLS handshake logic correctly identifies and rejects corrupted or tampered records, matching the reference OpenJDK behavior.

✅ Verification
Ran the `datachannel.handshake-test` namespace locally, confirming that the new `test-invalid-records` test case correctly expects an `SSLException` from the server engine and fails the handshake loop when the record is invalidated.

✨ Result
`TESTING.md` is updated to show `InvalidRecords` as completed, increasing total test coverage for robustness against invalid messages.

---
*PR created automatically by Jules for task [6067368039998016166](https://jules.google.com/task/6067368039998016166) started by @alpeware*