### PR TITLE
Add RespondToRetransmit DTLS test from TESTING.md

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -21,7 +21,7 @@
 - [x] [NoMacInitialClientHello](https://github.com/twosigma/OpenJDK/blob/master/test/jdk/javax/net/ssl/DTLS/NoMacInitialClientHello.java)
 - [x] [PacketLossRetransmission](https://github.com/twosigma/OpenJDK/blob/master/test/jdk/javax/net/ssl/DTLS/PacketLossRetransmission.java)
 - [x] [Reordered](https://github.com/twosigma/OpenJDK/blob/master/test/jdk/javax/net/ssl/DTLS/Reordered.java)
-- [ ] [RespondToRetransmit](https://github.com/twosigma/OpenJDK/blob/master/test/jdk/javax/net/ssl/DTLS/RespondToRetransmit.java)
+- [x] [RespondToRetransmit](https://github.com/twosigma/OpenJDK/blob/master/test/jdk/javax/net/ssl/DTLS/RespondToRetransmit.java)
 - [x] [Retransmission](https://github.com/twosigma/OpenJDK/blob/master/test/jdk/javax/net/ssl/DTLS/Retransmission.java)
 - [ ] [WeakCipherSuite](https://github.com/twosigma/OpenJDK/blob/master/test/jdk/javax/net/ssl/DTLS/WeakCipherSuite.java)
 

--- a/test/datachannel/handshake_test.clj
+++ b/test/datachannel/handshake_test.clj
@@ -904,3 +904,84 @@
       (.beginHandshake server-engine)
       (is (= :success (run-handshake-loop-retransmission client-engine server-engine)))
       (is (= "Retransmit OK" (exchange-data client-engine server-engine "Retransmit OK"))))))
+
+(defn- run-handshake-loop-respond-to-retransmit [client-engine server-engine]
+  (let [client-out (ByteBuffer/allocate 65536)
+        server-out (ByteBuffer/allocate 65536)
+        client-in (ByteBuffer/allocate 65536)
+        server-in (ByteBuffer/allocate 65536)
+        max-loops 200]
+    (.flip client-in)
+    (.flip server-in)
+    (loop [i 0
+           client-duplicated false]
+      (if (> i max-loops)
+        (throw (Exception. "Handshake failed to complete in max loops"))
+        (let [client-status (.getHandshakeStatus client-engine)
+              server-status (.getHandshakeStatus server-engine)]
+          (if (and (or (= client-status SSLEngineResult$HandshakeStatus/NOT_HANDSHAKING)
+                       (= client-status SSLEngineResult$HandshakeStatus/FINISHED))
+                   (or (= server-status SSLEngineResult$HandshakeStatus/NOT_HANDSHAKING)
+                       (= server-status SSLEngineResult$HandshakeStatus/FINISHED))
+                   (not (.hasRemaining client-in))
+                   (not (.hasRemaining server-in)))
+            :success
+            (let [res-c (dtls/handshake client-engine client-in client-out)
+                  packets-c (:packets res-c)
+                  ;; Duplicate the first flight of packets
+                  packets-to-send (if (and (not client-duplicated) (> (count packets-c) 0))
+                                    (concat packets-c packets-c)
+                                    packets-c)
+                  new-client-duplicated (or client-duplicated (> (count packets-c) 0))]
+              (.compact server-in)
+              (doseq [p packets-to-send]
+                (.put server-in (ByteBuffer/wrap p)))
+              (.flip server-in)
+              (let [res-s (dtls/handshake server-engine server-in server-out)
+                    packets-s (:packets res-s)]
+                (.compact client-in)
+                (doseq [p packets-s]
+                  (.put client-in (ByteBuffer/wrap p)))
+                (.flip client-in)
+                (let [c-status-after (.getHandshakeStatus client-engine)
+                      s-status-after (.getHandshakeStatus server-engine)
+                      timeout-c? (and (not (.hasRemaining client-in))
+                                      (not (.hasRemaining server-in))
+                                      (= c-status-after SSLEngineResult$HandshakeStatus/NEED_UNWRAP))
+                      timeout-s? (and (not (.hasRemaining client-in))
+                                      (not (.hasRemaining server-in))
+                                      (= s-status-after SSLEngineResult$HandshakeStatus/NEED_UNWRAP))]
+                  (when (or timeout-c? timeout-s?)
+                    (Thread/sleep 1000)
+                    (when timeout-c?
+                      (.clear client-out)
+                      (let [res (.wrap client-engine (ByteBuffer/allocate 0) client-out)]
+                        (.flip client-out)
+                        (when (> (.remaining client-out) 0)
+                          (let [arr (byte-array (.remaining client-out))]
+                            (.get client-out arr)
+                            (.compact server-in)
+                            (.put server-in (ByteBuffer/wrap arr))
+                            (.flip server-in)))))
+                    (when timeout-s?
+                      (.clear server-out)
+                      (let [res (.wrap server-engine (ByteBuffer/allocate 0) server-out)]
+                        (.flip server-out)
+                        (when (> (.remaining server-out) 0)
+                          (let [arr (byte-array (.remaining server-out))]
+                            (.get server-out arr)
+                            (.compact client-in)
+                            (.put client-in (ByteBuffer/wrap arr))
+                            (.flip client-in))))))
+                  (recur (inc i) new-client-duplicated))))))))))
+
+(deftest test-respond-to-retransmit
+  (testing "DTLS handshake responds to retransmitted flights"
+    (let [cert-data (dtls/generate-cert)
+          ctx (dtls/create-ssl-context (:cert cert-data) (:key cert-data))
+          client-engine (dtls/create-engine ctx true)
+          server-engine (dtls/create-engine ctx false)]
+      (.beginHandshake client-engine)
+      (.beginHandshake server-engine)
+      (is (= :success (run-handshake-loop-respond-to-retransmit client-engine server-engine)))
+      (is (= "Respond OK" (exchange-data client-engine server-engine "Respond OK"))))))


### PR DESCRIPTION
Implemented the `RespondToRetransmit` test case from `TESTING.md`.

This test verifies the DTLS engine's ability to handle duplicated network flights (retransmissions) without failing the handshake. The test simulates this by duplicating the client's first flight of packets and ensuring the server engine gracefully ignores the duplicate and completes the handshake, followed by a successful application data exchange. `TESTING.md` has been updated to mark this task as complete.

---
*PR created automatically by Jules for task [17833646733632020544](https://jules.google.com/task/17833646733632020544) started by @alpeware*