### PR TITLE
🧹 [Implement DTLSSignatureSchemes test from TESTING.md]

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -14,7 +14,7 @@
 - [ ] [DTLSRehandshakeWithCipherChangeTest](https://github.com/twosigma/OpenJDK/blob/master/test/jdk/javax/net/ssl/DTLS/DTLSRehandshakeWithCipherChangeTest.java)
 - [ ] [DTLSRehandshakeWithDataExTest](https://github.com/twosigma/OpenJDK/blob/master/test/jdk/javax/net/ssl/DTLS/DTLSRehandshakeWithDataExTest.java)
 - [x] [DTLSSequenceNumberTest](https://github.com/twosigma/OpenJDK/blob/master/test/jdk/javax/net/ssl/DTLS/DTLSSequenceNumberTest.java)
-- [ ] [DTLSSignatureSchemes](https://github.com/twosigma/OpenJDK/blob/master/test/jdk/javax/net/ssl/DTLS/DTLSSignatureSchemes.java)
+- [x] [DTLSSignatureSchemes](https://github.com/twosigma/OpenJDK/blob/master/test/jdk/javax/net/ssl/DTLS/DTLSSignatureSchemes.java)
 - [x] [DTLSUnsupportedCiphersTest](https://github.com/twosigma/OpenJDK/blob/master/test/jdk/javax/net/ssl/DTLS/DTLSUnsupportedCiphersTest.java)
 - [x] [InvalidCookie](https://github.com/twosigma/OpenJDK/blob/master/test/jdk/javax/net/ssl/DTLS/InvalidCookie.java)
 - [x] [InvalidRecords](https://github.com/twosigma/OpenJDK/blob/master/test/jdk/javax/net/ssl/DTLS/InvalidRecords.java)

--- a/test/datachannel/handshake_test.clj
+++ b/test/datachannel/handshake_test.clj
@@ -1009,3 +1009,82 @@
       (.beginHandshake server-engine)
       (is (= :success (run-handshake-loop-respond-to-retransmit client-engine server-engine)))
       (is (= "Respond OK" (exchange-data client-engine server-engine "Respond OK"))))))
+
+(defn- test-signature-schemes [server-schemes client-schemes exception-expected?]
+  (let [cert-data (dtls/generate-cert)
+        ctx (dtls/create-ssl-context (:cert cert-data) (:key cert-data))
+        client-engine (dtls/create-engine ctx true)
+        server-engine (dtls/create-engine ctx false)]
+
+    (when client-schemes
+      (let [params (.getSSLParameters client-engine)]
+        (.setSignatureSchemes params (into-array String client-schemes))
+        (.setSSLParameters client-engine params)))
+
+    (when server-schemes
+      (let [params (.getSSLParameters server-engine)]
+        (.setSignatureSchemes params (into-array String server-schemes))
+        (.setSSLParameters server-engine params)))
+
+    (.beginHandshake client-engine)
+    (.beginHandshake server-engine)
+
+    (if exception-expected?
+      (try
+        (run-handshake-loop client-engine server-engine)
+        (is false "Expected an exception during handshake, but none was thrown")
+        (catch javax.net.ssl.SSLHandshakeException e
+          (is true "Caught SSLHandshakeException"))
+        (catch javax.net.ssl.SSLProtocolException e
+          (is true "Caught SSLProtocolException"))
+        (catch javax.net.ssl.SSLException e
+          (is true "Caught SSLException")))
+      (do
+        (is (= :success (run-handshake-loop client-engine server-engine)))
+        (is (= "Signature OK" (exchange-data client-engine server-engine "Signature OK")))))))
+
+(deftest test-dtls-signature-schemes
+  (testing "DTLS signature schemes configuration"
+    ;; Note: We are using "rsa_pkcs1_sha256" here because the default certificate generated
+    ;; by dtls/generate-cert is an RSA certificate. "ecdsa_secp256r1_sha256" would require an ECDSA
+    ;; certificate which our test utility currently doesn't generate by default.
+    (test-signature-schemes ["rsa_pkcs1_sha256" "rsa_pss_rsae_sha256"]
+                            ["rsa_pkcs1_sha256" "rsa_pss_rsae_sha256"]
+                            false)
+    (test-signature-schemes ["rsa_pkcs1_sha256"]
+                            ["rsa_pkcs1_sha256"]
+                            false)
+    (test-signature-schemes nil
+                            ["rsa_pkcs1_sha256"]
+                            false)
+    (test-signature-schemes ["rsa_pkcs1_sha256"]
+                            nil
+                            false)
+    (test-signature-schemes []
+                            ["rsa_pkcs1_sha256"]
+                            true)
+    (test-signature-schemes ["rsa_pkcs1_sha256"]
+                            []
+                            true)
+    ;; Test with a non-existent signature algorithm that causes IllegalArgumentException
+    (let [cert-data (dtls/generate-cert)
+          ctx (dtls/create-ssl-context (:cert cert-data) (:key cert-data))
+          server-engine (dtls/create-engine ctx false)
+          params (.getSSLParameters server-engine)]
+      (try
+        (.setSignatureSchemes params (into-array String ["rsa_pkcs1_shaNA"]))
+        (.setSSLParameters server-engine params)
+        (catch IllegalArgumentException _
+          (is true "Caught IllegalArgumentException during setSignatureSchemes"))
+        (catch Exception e
+          ;; If it didn't throw IllegalArgumentException immediately, we expect it to fail during the handshake
+          (is (thrown? javax.net.ssl.SSLHandshakeException
+                       (let [client-engine (dtls/create-engine ctx true)]
+                         (.beginHandshake client-engine)
+                         (.beginHandshake server-engine)
+                         (run-handshake-loop client-engine server-engine)))))))
+
+    ;; Mismatched valid signature schemes cause SSLHandshakeException
+    (test-signature-schemes ["rsa_pss_rsae_sha256"]
+                            ["rsa_pkcs1_sha256"]
+                            true)))


### PR DESCRIPTION
🎯 What
Implemented the `DTLSSignatureSchemes` missing test case from `TESTING.md`. The test is added to `test/datachannel/handshake_test.clj` and checks DTLS signature schemes configurations similar to the OpenJDK version.

💡 Why
To ensure the DTLS engine correctly validates signature algorithms for mutual authentication and gracefully recovers or fails when invalid signature schemes are provided, ensuring compliance with DTLS requirements.

✅ Verification
Ran `clojure -M:test -m datachannel.test-runner` locally, and all tests including the new `test-dtls-signature-schemes` test passed.

✨ Result
Added robust test coverage for DTLS signature schemes and updated the tracking checklist in `TESTING.md` as done.

---
*PR created automatically by Jules for task [13972253992632900555](https://jules.google.com/task/13972253992632900555) started by @alpeware*