### PR TITLE
Add Shutdown Connection test and core chunk handling

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -44,7 +44,7 @@
     - [x] Resend Cookie Echo And Establish Connection
     - [ ] Resending Cookie Echo Too Many Times Aborts
     - [ ] Doesnt Send More Packets Until Cookie Ack Has Been Received
-    - [ ] Shutdown Connection
+    - [x] Shutdown Connection
     - [ ] Shutdown Timer Expires Too Many Time Closes Connection
     - [x] Establish Connection While Sending Data
     - [x] Send Message After Established

--- a/src/datachannel/core.clj
+++ b/src/datachannel/core.clj
@@ -135,6 +135,21 @@
 
         :sack nil
         :heartbeat-ack nil
+        :shutdown
+        (do
+           (let [packet {:src-port (:dst-port packet)
+                         :dst-port (:src-port packet)
+                         :verification-tag (:remote-ver-tag @state)
+                         :chunks [{:type :shutdown-ack}]}]
+              (.offer (:sctp-out connection) packet)))
+        :shutdown-ack
+        (do
+           (let [packet {:src-port (:dst-port packet)
+                         :dst-port (:src-port packet)
+                         :verification-tag (:remote-ver-tag @state)
+                         :chunks [{:type :shutdown-complete}]}]
+              (.offer (:sctp-out connection) packet)))
+        :shutdown-complete nil
         :abort (println "Received SCTP ABORT")
         nil))))
 

--- a/src/datachannel/sctp.clj
+++ b/src/datachannel/sctp.clj
@@ -137,6 +137,9 @@
 (defmethod decode-chunk-payload :shutdown-ack [_ _ chunk-data _ _ _]
   chunk-data)
 
+(defmethod decode-chunk-payload :shutdown-complete [_ _ chunk-data _ _ _]
+  chunk-data)
+
 (defn decode-abort-chunk [buf chunk-data val-len chunk-start]
   (.position buf (+ chunk-start val-len))
   chunk-data)
@@ -354,6 +357,10 @@
 
 (defmethod encode-chunk-payload :heartbeat-ack [_ ^ByteBuffer buf chunk]
   (encode-params buf (:params chunk)))
+
+(defmethod encode-chunk-payload :shutdown [_ ^ByteBuffer buf chunk])
+(defmethod encode-chunk-payload :shutdown-ack [_ ^ByteBuffer buf chunk])
+(defmethod encode-chunk-payload :shutdown-complete [_ ^ByteBuffer buf chunk])
 
 (defmethod encode-chunk-payload :default [_ ^ByteBuffer buf chunk]
   (when (:body chunk)

--- a/test/datachannel/sctp_robustness_test.clj
+++ b/test/datachannel/sctp_robustness_test.clj
@@ -559,6 +559,44 @@
       ;; Client processes COOKIE-ACK and becomes established
       (is (true? @client-opened) "Client should be in open state"))))
 
+(deftest shutdown-connection-test
+  (testing "Shutdown Connection"
+    (let [state (atom {:remote-ver-tag 12345})
+          out-queue (java.util.concurrent.LinkedBlockingQueue.)
+          connection {:state state
+                      :sctp-out out-queue}
+          handle-sctp-packet #'core/handle-sctp-packet]
+
+      ;; Simulate receiving a SHUTDOWN chunk
+      (let [shutdown-packet {:src-port 5000 :dst-port 5001 :verification-tag 12345
+                             :chunks [{:type :shutdown}]}]
+        (handle-sctp-packet shutdown-packet connection)
+
+        ;; Expect a SHUTDOWN-ACK chunk in response
+        (let [response-packet (.poll out-queue)]
+          (is response-packet "Should produce a response packet")
+          (is (= 5001 (:src-port response-packet)) "Should swap src/dst ports")
+          (is (= 5000 (:dst-port response-packet)) "Should swap src/dst ports")
+          (is (= 12345 (:verification-tag response-packet)) "Should use same verification tag")
+
+          (let [chunk (first (:chunks response-packet))]
+            (is (= :shutdown-ack (:type chunk)) "Chunk should be SHUTDOWN-ACK"))))
+
+      ;; Simulate receiving a SHUTDOWN-ACK chunk
+      (let [shutdown-ack-packet {:src-port 5000 :dst-port 5001 :verification-tag 12345
+                                 :chunks [{:type :shutdown-ack}]}]
+        (handle-sctp-packet shutdown-ack-packet connection)
+
+        ;; Expect a SHUTDOWN-COMPLETE chunk in response
+        (let [response-packet (.poll out-queue)]
+          (is response-packet "Should produce a response packet")
+          (is (= 5001 (:src-port response-packet)) "Should swap src/dst ports")
+          (is (= 5000 (:dst-port response-packet)) "Should swap src/dst ports")
+          (is (= 12345 (:verification-tag response-packet)) "Should use same verification tag")
+
+          (let [chunk (first (:chunks response-packet))]
+            (is (= :shutdown-complete (:type chunk)) "Chunk should be SHUTDOWN-COMPLETE")))))))
+
 (deftest resend-cookie-echo-and-establish-connection-test
   (testing "Resend Cookie Echo And Establish Connection"
     (let [client-state (atom {:remote-ver-tag 0 :local-ver-tag 1111 :next-tsn 100 :ssn 0})


### PR DESCRIPTION
Implemented the `Shutdown Connection` test case from `TESTING.md`. This included adding basic handling for `:shutdown` and `:shutdown-ack` chunk types in `datachannel.core/handle-sctp-packet` to correctly complete the shutdown state machine flow. Also added empty payload encode/decode definitions for the shutdown sequence chunks in `sctp.clj`. Updated `TESTING.md` to check off the newly implemented test.

---
*PR created automatically by Jules for task [12981949081534180335](https://jules.google.com/task/12981949081534180335) started by @alpeware*