### PR TITLE
🧹 [Implement 'Connection Can Continue From First Init Ack' SCTP Robustness Test]

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -128,7 +128,7 @@
     - [ ] Handles Forward Tsn Out Of Order With Stream Resetting
     - [ ] Resent Init Has Same Parameters
     - [x] Resent Init Ack Has Different Parameters
-    - [ ] Connection Can Continue From First Init Ack
+    - [x] Connection Can Continue From First Init Ack
     - [ ] Connection Can Continue From Second Init Ack
     - [ ] Handover Preserves Stream Reset State
     - [ ] Establish Simultaneous Connection With Lost Data

--- a/test/datachannel/sctp_init_ack_robustness_test.clj
+++ b/test/datachannel/sctp_init_ack_robustness_test.clj
@@ -1,0 +1,74 @@
+(ns datachannel.sctp-init-ack-robustness-test
+  (:require [clojure.test :refer :all]
+            [datachannel.core :as core]))
+
+(deftest connection-can-continue-from-first-init-ack-test
+  (testing "Connection Can Continue From First Init Ack"
+    (let [client-state (atom {:remote-ver-tag 0 :local-ver-tag 1111 :next-tsn 100 :ssn 0 :state :closed})
+          client-out (java.util.concurrent.LinkedBlockingQueue.)
+          client-opened (atom false)
+          client-conn {:state client-state
+                       :sctp-out client-out
+                       :on-open (atom (fn [] (reset! client-opened true)))}
+
+          server-state (atom {:remote-ver-tag 0 :local-ver-tag 2222 :next-tsn 200 :ssn 0 :state :closed})
+          server-out (java.util.concurrent.LinkedBlockingQueue.)
+          server-opened (atom false)
+          server-conn {:state server-state
+                       :sctp-out server-out
+                       :on-open (atom (fn [] (reset! server-opened true)))}
+
+          handle-sctp-packet #'core/handle-sctp-packet]
+
+      ;; 1. Client initiates connection with INIT
+      (reset! client-state (assoc @client-state :state :cookie-wait))
+      (let [init-packet {:src-port 5000 :dst-port 5001 :verification-tag 0
+                         :chunks [{:type :init
+                                   :init-tag (:local-ver-tag @client-state)
+                                   :a-rwnd 100000
+                                   :outbound-streams 10
+                                   :inbound-streams 10
+                                   :initial-tsn (:next-tsn @client-state)
+                                   :params {}}]}]
+
+        ;; Server receives INIT first time
+        (handle-sctp-packet init-packet server-conn)
+
+        ;; Server generates first INIT-ACK
+        (let [init-ack-packet1 (.poll server-out)]
+          (is init-ack-packet1 "Server should produce first INIT-ACK")
+
+          ;; Server receives the exact same INIT again (e.g. retransmission by client)
+          (handle-sctp-packet init-packet server-conn)
+
+          ;; Server generates another INIT-ACK
+          (let [init-ack-packet2 (.poll server-out)]
+            (is init-ack-packet2 "Server should produce second INIT-ACK")
+
+            ;; Verify that they are indeed distinct INIT-ACKs (cookie differs)
+            (let [chunk1 (first (:chunks init-ack-packet1))
+                  chunk2 (first (:chunks init-ack-packet2))]
+              (is (not= (:cookie (:params chunk1))
+                        (:cookie (:params chunk2)))
+                  "Second INIT-ACK should have a different cookie than the first"))
+
+            ;; Client proceeds using the FIRST INIT-ACK
+            (handle-sctp-packet init-ack-packet1 client-conn)
+
+            (let [cookie-echo-packet (.poll client-out)]
+              (is cookie-echo-packet "Client should produce COOKIE-ECHO in response to INIT-ACK1")
+
+              ;; Server receives COOKIE-ECHO
+              (handle-sctp-packet cookie-echo-packet server-conn)
+
+              (let [cookie-ack-packet (.poll server-out)]
+                (is cookie-ack-packet "Server should produce COOKIE-ACK in response to COOKIE-ECHO")
+
+                ;; Verify server state transitioned properly
+                (is (= :established (:state @server-state)) "Server should transition to established")
+                (is (true? @server-opened) "Server on-open should be called")
+
+                ;; Client receives COOKIE-ACK
+                (handle-sctp-packet cookie-ack-packet client-conn)
+                (is (= :established (:state @client-state)) "Client should transition to established")
+                (is (true? @client-opened) "Client on-open should be called")))))))))

--- a/test/datachannel/test_runner.clj
+++ b/test/datachannel/test_runner.clj
@@ -12,6 +12,7 @@
             [datachannel.webrtc-extended-test]
             [datachannel.sctp-robustness-test]
             [datachannel.sctp-state-machine-test]
+            [datachannel.sctp-init-ack-robustness-test]
             [datachannel.rehandshake-test]))
 
 (defn -main []
@@ -27,7 +28,8 @@
                                              'datachannel.webrtc-integration-test
                                              'datachannel.webrtc-extended-test
                                              'datachannel.sctp-robustness-test
-                                             'datachannel.sctp-state-machine-test)]
+                                             'datachannel.sctp-state-machine-test
+                                             'datachannel.sctp-init-ack-robustness-test)]
     (if (> (+ fail error) 0)
       (System/exit 1)
       (System/exit 0))))


### PR DESCRIPTION
🎯 What
Implemented the missing 'Connection Can Continue From First Init Ack' SCTP robustness test from `TESTING.md`. The test verifies that if the server issues multiple INIT-ACK chunks (due to client retransmitting INIT chunks), the client can establish the connection correctly upon receiving the first INIT-ACK and proceeding with the handshake.

💡 Why
To improve test coverage for SCTP connection establishment and increase confidence in handling edge cases such as INIT retransmissions and overlapping handshake messages as documented in `TESTING.md`.

✅ Verification
- Created `test/datachannel/sctp_init_ack_robustness_test.clj` and tested successfully.
- Registered the new test in `test/datachannel/test_runner.clj`.
- Executed `clojure -M:test -m datachannel.test-runner` confirming 0 failures and 0 errors.
- Marked the test case as checked `[x]` in `TESTING.md`.

✨ Result
A more robust SCTP data channel implementation test suite with better edge-case testing for 4-way handshake failures and duplicate messages.

---
*PR created automatically by Jules for task [16504686171263280722](https://jules.google.com/task/16504686171263280722) started by @alpeware*