### PR TITLE
🧹 Implement Cannot Send Empty Messages test case

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -79,7 +79,7 @@
     - [ ] Sends Messages With Low Lifetime
     - [ ] Discards Messages With Low Lifetime If Must Buffer
     - [ ] Respects Per Stream Queue Limit
-    - [ ] Cannot Send Empty Messages
+    - [x] Cannot Send Empty Messages
     - [ ] Cannot Send Too Large Message
     - [ ] Has Reasonable Buffered Amount Values
     - [ ] Has Default On Buffered Amount Low Value Zero

--- a/src/datachannel/core.clj
+++ b/src/datachannel/core.clj
@@ -343,6 +343,8 @@
     connection))
 
 (defn send-data [connection ^bytes payload stream-id protocol]
+  (when (zero? (alength payload))
+    (throw (ex-info "Cannot send empty message" {:type :empty-payload})))
   (let [state (:state connection)
         ver-tag (:remote-ver-tag @state)
         tsn (let [t (:next-tsn @state)]

--- a/test/datachannel/sctp_message_test.clj
+++ b/test/datachannel/sctp_message_test.clj
@@ -1,0 +1,12 @@
+(ns datachannel.sctp-message-test
+  (:require [clojure.test :refer :all]
+            [datachannel.core :as core]))
+
+(deftest cannot-send-empty-messages-test
+  (testing "Cannot Send Empty Messages"
+    (let [out (java.util.concurrent.LinkedBlockingQueue.)
+          state (atom {:remote-ver-tag 0 :next-tsn 0 :ssn 0})
+          conn {:sctp-out out :state state}
+          payload (byte-array 0)]
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Cannot send empty message"
+            (core/send-data conn payload 1 :webrtc/string))))))

--- a/test/datachannel/test_runner.clj
+++ b/test/datachannel/test_runner.clj
@@ -13,7 +13,8 @@
             [datachannel.sctp-robustness-test]
             [datachannel.sctp-state-machine-test]
             [datachannel.sctp-init-ack-robustness-test]
-            [datachannel.rehandshake-test]))
+            [datachannel.rehandshake-test]
+            [datachannel.sctp-message-test]))
 
 (defn -main []
   (let [{:keys [fail error]} (test/run-tests 'datachannel.sctp-test
@@ -29,7 +30,8 @@
                                              'datachannel.webrtc-extended-test
                                              'datachannel.sctp-robustness-test
                                              'datachannel.sctp-state-machine-test
-                                             'datachannel.sctp-init-ack-robustness-test)]
+                                             'datachannel.sctp-init-ack-robustness-test
+                                             'datachannel.sctp-message-test)]
     (if (> (+ fail error) 0)
       (System/exit 1)
       (System/exit 0))))


### PR DESCRIPTION
🎯 What
Implemented the "Cannot Send Empty Messages" test case from `TESTING.md`.
Added explicit validation to `send-data` in `src/datachannel/core.clj` to throw an exception with type `:empty-payload` when the payload has zero length.
Created `test/datachannel/sctp_message_test.clj` to assert this behavior.

💡 Why
To ensure compliance with the SCTP/DataChannel edge cases defined in `TESTING.md`. Sending empty payload messages can violate protocol constraints, and validating this prior to encoding prevents silent errors or broken state machines further down the pipeline.

✅ Verification
Ran `clojure -M:test -m datachannel.test-runner`, all 60 tests and 751 assertions pass cleanly, including the newly added test.

✨ Result
Empty messages are now explicitly caught and rejected at the application edge `send-data`, and the corresponding checklist item in `TESTING.md` is completed.

---
*PR created automatically by Jules for task [8816149320056018117](https://jules.google.com/task/8816149320056018117) started by @alpeware*