### PR TITLE
🧹 Implement 'Establish Simultaneous Connection With Lost Data' test

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -131,5 +131,5 @@
     - [x] Connection Can Continue From First Init Ack
     - [x] Connection Can Continue From Second Init Ack
     - [ ] Handover Preserves Stream Reset State
-    - [ ] Establish Simultaneous Connection With Lost Data
+    - [x] Establish Simultaneous Connection With Lost Data
     - [ ] Advance Time Does Not Trigger Spurious Ack

--- a/test/datachannel/sctp_establish_simultaneous_lost_data_test.clj
+++ b/test/datachannel/sctp_establish_simultaneous_lost_data_test.clj
@@ -1,0 +1,82 @@
+(ns datachannel.sctp-establish-simultaneous-lost-data-test
+  (:require [clojure.test :refer :all]
+            [datachannel.core :as core]))
+
+(deftest establish-simultaneous-connection-with-lost-data-test
+  (testing "Establish Simultaneous Connection With Lost Data"
+    (let [state-a (atom {:remote-tsn 0 :remote-ver-tag 0 :next-tsn 1000 :ssn 0 :state :closed})
+          state-z (atom {:remote-tsn 0 :remote-ver-tag 0 :next-tsn 2000 :ssn 0 :state :closed})
+          out-a (java.util.concurrent.LinkedBlockingQueue.)
+          out-z (java.util.concurrent.LinkedBlockingQueue.)
+          conn-a {:state state-a :sctp-out out-a :on-open (atom nil) :on-message (atom nil) :on-data (atom nil) :selector nil}
+          conn-z {:state state-z :sctp-out out-z :on-open (atom nil) :on-message (atom nil) :on-data (atom nil) :selector nil}
+          handle-sctp-packet #'core/handle-sctp-packet
+          z-messages (atom [])]
+
+      (reset! (:on-message conn-z) (fn [msg] (swap! z-messages conj msg)))
+
+      ;; A starts connection: sends INIT
+      (reset! state-a (merge @state-a {:state :cookie-wait :init-tag 1111}))
+      (let [init-packet-a {:src-port 5000 :dst-port 5001 :verification-tag 0
+                           :chunks [{:type :init :init-tag 1111 :a-rwnd 100000
+                                     :outbound-streams 1 :inbound-streams 1
+                                     :initial-tsn 1000 :params {}}]}]
+
+        ;; Z also starts connection: sends INIT (Simultaneous Connect)
+        (reset! state-z (merge @state-z {:state :cookie-wait :init-tag 2222}))
+        (let [init-packet-z {:src-port 5001 :dst-port 5000 :verification-tag 0
+                             :chunks [{:type :init :init-tag 2222 :a-rwnd 100000
+                                       :outbound-streams 1 :inbound-streams 1
+                                       :initial-tsn 2000 :params {}}]}]
+
+          ;; Queue data on A BEFORE it receives Z's INIT-ACK
+          (core/send-data conn-a (.getBytes "hello" "UTF-8") 1 :webrtc/string)
+          (let [data-packet-a (.poll out-a)]
+            (is data-packet-a "A should queue DATA packet")
+            (is (= :data (-> data-packet-a :chunks first :type)))
+
+            ;; Setup collision:
+            ;; A receives Z's INIT
+            (handle-sctp-packet init-packet-z conn-a)
+            ;; Z receives A's INIT
+            (handle-sctp-packet init-packet-a conn-z)
+
+            (let [init-ack-from-a (.poll out-a)
+                  init-ack-from-z (.poll out-z)]
+              (is init-ack-from-a "A should send INIT-ACK")
+              (is init-ack-from-z "Z should send INIT-ACK")
+
+              ;; Z receives A's INIT-ACK
+              (handle-sctp-packet init-ack-from-a conn-z)
+              ;; A receives Z's INIT-ACK
+              (handle-sctp-packet init-ack-from-z conn-a)
+
+              (let [cookie-echo-from-z (.poll out-z)
+                    cookie-echo-from-a (.poll out-a)]
+                (is cookie-echo-from-z "Z should send COOKIE-ECHO")
+                (is cookie-echo-from-a "A should send COOKIE-ECHO")
+
+                ;; We drop the DATA packet that A previously queued (data-packet-a)
+                ;; Z receives A's COOKIE-ECHO
+                (handle-sctp-packet cookie-echo-from-a conn-z)
+                ;; A receives Z's COOKIE-ECHO
+                (handle-sctp-packet cookie-echo-from-z conn-a)
+
+                (let [cookie-ack-from-z (.poll out-z)
+                      cookie-ack-from-a (.poll out-a)]
+                  (is cookie-ack-from-z "Z should send COOKIE-ACK")
+                  (is cookie-ack-from-a "A should send COOKIE-ACK")
+
+                  ;; Both receive COOKIE-ACK
+                  (handle-sctp-packet cookie-ack-from-a conn-z)
+                  (handle-sctp-packet cookie-ack-from-z conn-a)
+
+                  (is (= :established (:state @state-a)) "A should be ESTABLISHED")
+                  (is (= :established (:state @state-z)) "Z should be ESTABLISHED")
+                  (is (empty? @z-messages) "Z should not have received the message yet (packet lost)")
+
+                  ;; Simulate timeout by A retransmitting the lost DATA packet
+                  (handle-sctp-packet data-packet-a conn-z)
+
+                  (is (= 1 (count @z-messages)) "Z should have received the message")
+                  (is (= "hello" (String. ^bytes (first @z-messages) "UTF-8")) "Message should be 'hello'"))))))))))

--- a/test/datachannel/test_runner.clj
+++ b/test/datachannel/test_runner.clj
@@ -14,7 +14,8 @@
             [datachannel.sctp-state-machine-test]
             [datachannel.sctp-init-ack-robustness-test]
             [datachannel.rehandshake-test]
-            [datachannel.sctp-message-test]))
+            [datachannel.sctp-message-test]
+            [datachannel.sctp-establish-simultaneous-lost-data-test]))
 
 (defn -main []
   (let [{:keys [fail error]} (test/run-tests 'datachannel.sctp-test
@@ -31,7 +32,8 @@
                                              'datachannel.sctp-robustness-test
                                              'datachannel.sctp-state-machine-test
                                              'datachannel.sctp-init-ack-robustness-test
-                                             'datachannel.sctp-message-test)]
+                                             'datachannel.sctp-message-test
+                                             'datachannel.sctp-establish-simultaneous-lost-data-test)]
     (if (> (+ fail error) 0)
       (System/exit 1)
       (System/exit 0))))


### PR DESCRIPTION
🎯 What
Implemented the `establish-simultaneous-connection-with-lost-data-test` test case from the `TESTING.md` checklist in a new file `test/datachannel/sctp_establish_simultaneous_lost_data_test.clj`.

💡 Why
This fulfills the goal of porting missing tests from the WebRTC `dcsctp` Rust repository to ensure the Clojure implementation of WebRTC Data Channels meets standard specifications. The specific test covers connection establishment robustly handling a scenario where a setup collision occurs (both sides send `INIT` simultaneously) and queued application data (`DATA` chunk) is lost and subsequently retransmitted.

✅ Verification
Ran the entire test suite `clojure -M:test -m datachannel.test-runner` ensuring the new test runs successfully and no regressions are introduced (61 tests, 764 assertions, 0 failures, 0 errors).
Updated `TESTING.md` to reflect completion of the test case.

✨ Result
A more complete robustness testing suite for the SCTP implementation.

---
*PR created automatically by Jules for task [16722621841838847970](https://jules.google.com/task/16722621841838847970) started by @alpeware*