### PR TITLE
✅ Add test and handling for unknown chunks

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -72,7 +72,7 @@
     - [ ] Close Connection After Too Many Retransmissions
     - [ ] Recover On Last Retransmission
     - [ ] Send Many Fragmented Messages With Limited Rtx
-    - [ ] Receiving Unknown Chunk Responds With Error
+    - [x] Receiving Unknown Chunk Responds With Error
     - [ ] Receiving Error Chunk Reports As Callback
     - [ ] Set Max Message Size
     - [x] Send Many Messages

--- a/src/datachannel/core.clj
+++ b/src/datachannel/core.clj
@@ -166,7 +166,20 @@
            (swap! state assoc :state :closed)
            nil)
         :abort (println "Received SCTP ABORT")
-        nil))))
+        (let [type-val (:type chunk)]
+          (when (number? type-val)
+            (let [upper-bits (bit-shift-right (bit-and type-val 0xC0) 6)]
+              (cond
+                (= upper-bits 1) ;; 01: discard packet and report
+                (let [packet {:src-port (:dst-port packet)
+                              :dst-port (:src-port packet)
+                              :verification-tag (:remote-ver-tag @state)
+                              :chunks [{:type :error
+                                        :causes [{:cause-code 6 ;; Unrecognized Chunk Type
+                                                  :chunk-data (:body chunk)}]}]}]
+                  (.offer (:sctp-out connection) packet))
+                ;; Other bits (00, 10, 11) will just skip or discard as required, no explicit response needed for now.
+                :else nil))))))))
 
 
 (defn- run-loop [^DatagramChannel channel ^Selector selector ^SSLEngine ssl-engine peer-addr connection & [initial-data]]

--- a/test/datachannel/sctp_unknown_chunk_test.clj
+++ b/test/datachannel/sctp_unknown_chunk_test.clj
@@ -1,0 +1,31 @@
+(ns datachannel.sctp-unknown-chunk-test
+  (:require [clojure.test :refer :all]
+            [datachannel.core :as core]
+            [datachannel.sctp :as sctp]))
+
+(deftest receiving-unknown-chunk-responds-with-error-test
+  (testing "Receiving Unknown Chunk Responds With Error (upper bits 01)"
+    (let [state (atom {:remote-ver-tag 1234 :next-tsn 1000 :ssn 0 :state :established})
+          out (java.util.concurrent.LinkedBlockingQueue.)
+          conn {:state state :sctp-out out :on-open (atom nil) :on-close (atom nil) :selector nil}
+          handle-sctp-packet #'core/handle-sctp-packet]
+
+      (let [unknown-chunk {:type 0x49 ;; 0x49 = 01001001 binary, upper bits are 01
+                           :flags 0
+                           :length 8
+                           :body (byte-array [1 2 3 4])}
+            packet {:src-port 5000
+                    :dst-port 5001
+                    :verification-tag 0
+                    :chunks [unknown-chunk]}]
+        (handle-sctp-packet packet conn))
+
+      (let [error-packet (.poll out)]
+        (is error-packet "Connection should send an ERROR packet in response to unknown chunk with 01 upper bits")
+        (when error-packet
+          (let [error-chunk (first (:chunks error-packet))]
+            (is (= :error (:type error-chunk)))
+            (is (= 1 (count (:causes error-chunk))))
+            (let [cause (first (:causes error-chunk))]
+              (is (= 6 (:cause-code cause)) "Cause code should be 6 (Unrecognized Chunk Type)")
+              (is (= (seq [1 2 3 4]) (seq (:chunk-data cause))) "Cause should contain the original chunk data"))))))))

--- a/test/datachannel/test_runner.clj
+++ b/test/datachannel/test_runner.clj
@@ -15,7 +15,8 @@
             [datachannel.sctp-init-ack-robustness-test]
             [datachannel.rehandshake-test]
             [datachannel.sctp-message-test]
-            [datachannel.sctp-establish-simultaneous-lost-data-test]))
+            [datachannel.sctp-establish-simultaneous-lost-data-test]
+            [datachannel.sctp-unknown-chunk-test]))
 
 (defn -main []
   (let [{:keys [fail error]} (test/run-tests 'datachannel.sctp-test
@@ -33,7 +34,8 @@
                                              'datachannel.sctp-state-machine-test
                                              'datachannel.sctp-init-ack-robustness-test
                                              'datachannel.sctp-message-test
-                                             'datachannel.sctp-establish-simultaneous-lost-data-test)]
+                                             'datachannel.sctp-establish-simultaneous-lost-data-test
+                                             'datachannel.sctp-unknown-chunk-test)]
     (if (> (+ fail error) 0)
       (System/exit 1)
       (System/exit 0))))


### PR DESCRIPTION
Implemented the missing test case `Receiving Unknown Chunk Responds With Error` from `TESTING.md`. Included the necessary core functionality to check the highest-order bits of unknown chunks and discard the packet while sending an `ERROR` chunk with cause code 6 if the bits are `01`. Updated the test runner to execute the new test case.

---
*PR created automatically by Jules for task [8785901248700231317](https://jules.google.com/task/8785901248700231317) started by @alpeware*