### PR TITLE
feat: Prevent sending messages larger than SCTP chunk payload capacity

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -80,7 +80,7 @@
     - [ ] Discards Messages With Low Lifetime If Must Buffer
     - [ ] Respects Per Stream Queue Limit
     - [x] Cannot Send Empty Messages
-    - [ ] Cannot Send Too Large Message
+    - [x] Cannot Send Too Large Message
     - [ ] Has Reasonable Buffered Amount Values
     - [ ] Has Default On Buffered Amount Low Value Zero
     - [ ] Triggers On Buffered Amount Low With Default Value Zero

--- a/src/datachannel/core.clj
+++ b/src/datachannel/core.clj
@@ -356,8 +356,11 @@
     connection))
 
 (defn send-data [connection ^bytes payload stream-id protocol]
-  (when (zero? (alength payload))
-    (throw (ex-info "Cannot send empty message" {:type :empty-payload})))
+  (let [len (alength payload)]
+    (when (zero? len)
+      (throw (ex-info "Cannot send empty message" {:type :empty-payload})))
+    (when (> len 65519)
+      (throw (ex-info "Cannot send too large message" {:type :too-large}))))
   (let [state (:state connection)
         ver-tag (:remote-ver-tag @state)
         tsn (let [t (:next-tsn @state)]

--- a/test/datachannel/sctp_message_test.clj
+++ b/test/datachannel/sctp_message_test.clj
@@ -10,3 +10,13 @@
           payload (byte-array 0)]
       (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Cannot send empty message"
             (core/send-data conn payload 1 :webrtc/string))))))
+
+(deftest cannot-send-too-large-message-test
+  (testing "Cannot Send Too Large Message"
+    (let [out (java.util.concurrent.LinkedBlockingQueue.)
+          state (atom {:remote-ver-tag 0 :next-tsn 0 :ssn 0})
+          conn {:sctp-out out :state state}
+          ;; Max chunk size is 65535, DATA header is 16 bytes. Max payload is 65519.
+          payload (byte-array 65520)]
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Cannot send too large message"
+            (core/send-data conn payload 1 :webrtc/string))))))


### PR DESCRIPTION
Added payload length constraint in `send-data` to reject unfragmented payloads exceeding 65519 bytes, preventing incorrect IP fragmentation / malformed packets. Includes the corresponding test required by `TESTING.md` ("Cannot Send Too Large Message").

---
*PR created automatically by Jules for task [15174339075200598513](https://jules.google.com/task/15174339075200598513) started by @alpeware*