### PR TITLE
feat: Implement Receiving Error Chunk Reports As Callback test

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -73,7 +73,7 @@
     - [ ] Recover On Last Retransmission
     - [ ] Send Many Fragmented Messages With Limited Rtx
     - [x] Receiving Unknown Chunk Responds With Error
-    - [ ] Receiving Error Chunk Reports As Callback
+    - [x] Receiving Error Chunk Reports As Callback
     - [ ] Set Max Message Size
     - [x] Send Many Messages
     - [ ] Sends Messages With Low Lifetime

--- a/src/datachannel/core.clj
+++ b/src/datachannel/core.clj
@@ -165,6 +165,9 @@
         (do
            (swap! state assoc :state :closed)
            nil)
+        :error
+        (when-let [cb @(:on-error connection)]
+          (cb (:causes chunk)))
         :abort (println "Received SCTP ABORT")
         (let [type-val (:type chunk)]
           (when (number? type-val)
@@ -286,6 +289,7 @@
                     :on-message (atom nil)
                     :on-data (atom nil)
                     :on-open (atom nil)
+                    :on-error (atom nil)
                     :cert-data cert-data
                     :ice-ufrag (:ice-ufrag options)
                     :ice-pwd (:ice-pwd options)

--- a/test/datachannel/sctp_error_chunk_test.clj
+++ b/test/datachannel/sctp_error_chunk_test.clj
@@ -1,0 +1,25 @@
+(ns datachannel.sctp-error-chunk-test
+  (:require [clojure.test :refer :all]
+            [datachannel.core :as core]))
+
+(deftest receiving-error-chunk-reports-as-callback-test
+  (testing "Receiving Error Chunk Reports As Callback"
+    (let [state-atom (atom {:remote-tsn 0 :remote-ver-tag 0 :next-tsn 1000 :ssn 0 :state :established})
+          out-queue (java.util.concurrent.LinkedBlockingQueue.)
+          error-called (atom false)
+          received-causes (atom nil)
+          on-error (atom (fn [causes]
+                           (reset! error-called true)
+                           (reset! received-causes causes)))
+          conn {:state state-atom :sctp-out out-queue :on-error on-error}
+          handle-sctp-packet #'core/handle-sctp-packet
+
+          error-packet {:src-port 5000 :dst-port 5001 :verification-tag 0
+                        :chunks [{:type :error
+                                  :causes [{:cause-code 1 :chunk-data (byte-array 0)}]}]}]
+
+      (handle-sctp-packet error-packet conn)
+
+      (is @error-called "The :on-error callback should have been called")
+      (is (= 1 (count @received-causes)) "There should be one error cause")
+      (is (= 1 (:cause-code (first @received-causes))) "The cause code should match the received cause code"))))

--- a/test/datachannel/test_runner.clj
+++ b/test/datachannel/test_runner.clj
@@ -16,7 +16,8 @@
             [datachannel.rehandshake-test]
             [datachannel.sctp-message-test]
             [datachannel.sctp-establish-simultaneous-lost-data-test]
-            [datachannel.sctp-unknown-chunk-test]))
+            [datachannel.sctp-unknown-chunk-test]
+            [datachannel.sctp-error-chunk-test]))
 
 (defn -main []
   (let [{:keys [fail error]} (test/run-tests 'datachannel.sctp-test
@@ -35,7 +36,8 @@
                                              'datachannel.sctp-init-ack-robustness-test
                                              'datachannel.sctp-message-test
                                              'datachannel.sctp-establish-simultaneous-lost-data-test
-                                             'datachannel.sctp-unknown-chunk-test)]
+                                             'datachannel.sctp-unknown-chunk-test
+                                             'datachannel.sctp-error-chunk-test)]
     (if (> (+ fail error) 0)
       (System/exit 1)
       (System/exit 0))))


### PR DESCRIPTION
This PR implements the missing "Receiving Error Chunk Reports As Callback" test from `TESTING.md`. It adds functionality to `core/handle-sctp-packet` to properly process `:error` chunks by invoking a newly added `:on-error` callback on the connection. The feature is verified by a new dedicated test file `sctp_error_chunk_test.clj` which asserts that the `:on-error` callback correctly receives the error causes when an `ERROR` chunk is parsed.

---
*PR created automatically by Jules for task [6819285216042547574](https://jules.google.com/task/6819285216042547574) started by @alpeware*