### PR TITLE
feat: implement configurable max message size for SCTP sockets

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -74,7 +74,7 @@
     - [ ] Send Many Fragmented Messages With Limited Rtx
     - [x] Receiving Unknown Chunk Responds With Error
     - [x] Receiving Error Chunk Reports As Callback
-    - [ ] Set Max Message Size
+    - [x] Set Max Message Size
     - [x] Send Many Messages
     - [ ] Sends Messages With Low Lifetime
     - [ ] Discards Messages With Low Lifetime If Must Buffer

--- a/src/datachannel/core.clj
+++ b/src/datachannel/core.clj
@@ -359,11 +359,16 @@
 
     connection))
 
+(defn set-max-message-size! [connection max-size]
+  (swap! (:state connection) assoc :max-message-size max-size))
+
 (defn send-data [connection ^bytes payload stream-id protocol]
-  (let [len (alength payload)]
+  (let [state (:state connection)
+        len (alength payload)
+        max-size (get @state :max-message-size 65519)]
     (when (zero? len)
       (throw (ex-info "Cannot send empty message" {:type :empty-payload})))
-    (when (> len 65519)
+    (when (> len max-size)
       (throw (ex-info "Cannot send too large message" {:type :too-large}))))
   (let [state (:state connection)
         ver-tag (:remote-ver-tag @state)

--- a/test/datachannel/sctp_max_message_size_test.clj
+++ b/test/datachannel/sctp_max_message_size_test.clj
@@ -1,0 +1,32 @@
+(ns datachannel.sctp-max-message-size-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [datachannel.core :as core]))
+
+(deftest set-max-message-size-test
+  (testing "Configured max message size is enforced in send-data"
+    (let [connection {:state (atom {:remote-ver-tag 1234
+                                    :local-ver-tag 5678
+                                    :next-tsn 0
+                                    :ssn 0
+                                    :state :established})
+                      :sctp-out (java.util.concurrent.LinkedBlockingQueue.)}]
+
+      (core/set-max-message-size! connection 42)
+
+      (is (= 42 (:max-message-size @(:state connection))))
+
+      (let [payload (byte-array 43)]
+        (try
+          (core/send-data connection payload 0 :webrtc/string)
+          (is false "Expected exception due to too large payload")
+          (catch clojure.lang.ExceptionInfo e
+            (is (= :too-large (:type (ex-data e))))
+            (is (= "Cannot send too large message" (ex-message e))))))
+
+      ;; Valid payload size should not throw
+      (let [payload (byte-array 42)]
+        (try
+          (core/send-data connection payload 0 :webrtc/string)
+          (is true)
+          (catch Exception e
+            (is false "Did not expect exception for valid payload size")))))))

--- a/test/datachannel/test_runner.clj
+++ b/test/datachannel/test_runner.clj
@@ -17,7 +17,8 @@
             [datachannel.sctp-message-test]
             [datachannel.sctp-establish-simultaneous-lost-data-test]
             [datachannel.sctp-unknown-chunk-test]
-            [datachannel.sctp-error-chunk-test]))
+            [datachannel.sctp-error-chunk-test]
+            [datachannel.sctp-max-message-size-test]))
 
 (defn -main []
   (let [{:keys [fail error]} (test/run-tests 'datachannel.sctp-test
@@ -37,7 +38,8 @@
                                              'datachannel.sctp-message-test
                                              'datachannel.sctp-establish-simultaneous-lost-data-test
                                              'datachannel.sctp-unknown-chunk-test
-                                             'datachannel.sctp-error-chunk-test)]
+                                             'datachannel.sctp-error-chunk-test
+                                             'datachannel.sctp-max-message-size-test)]
     (if (> (+ fail error) 0)
       (System/exit 1)
       (System/exit 0))))


### PR DESCRIPTION
Implemented the `Set Max Message Size` SCTP test case from `TESTING.md` by:
1. Adding `datachannel.core/set-max-message-size!` to configure the limit on the connection state.
2. Updating `datachannel.core/send-data` to read `(:max-message-size @state)` (defaulting to 65519) and throwing `:too-large` if exceeded.
3. Creating `datachannel.sctp-max-message-size-test` to unit test this behavior.
4. Adding the test to `test_runner.clj` and marking it done in `TESTING.md`.

---
*PR created automatically by Jules for task [14393825573353367543](https://jules.google.com/task/14393825573353367543) started by @alpeware*