### PR TITLE
feat: implement 'One Peer Reconnects' test and logic

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -62,7 +62,7 @@
     - [ ] Send Reset Stream When Streams Ready
     - [ ] Reset Stream Will Make Chunks Start At Zero Ssn
     - [ ] Reset Stream Will Only Reset The Requested Streams
-    - [ ] One Peer Reconnects
+    - [x] One Peer Reconnects
     - [ ] One Peer Reconnects With Pending Data
     - [ ] Send Message With Limited Rtx
     - [ ] Close Connection After First Failed Transmission

--- a/src/datachannel/core.clj
+++ b/src/datachannel/core.clj
@@ -84,7 +84,9 @@
         :init
         (do
           (swap! state assoc :remote-ver-tag (:init-tag chunk)
-                             :remote-tsn (dec (:initial-tsn chunk)))
+                             :remote-tsn (dec (:initial-tsn chunk))
+                             :ssn 0
+                             :state :cookie-wait)
           (let [cookie-bytes (let [b (byte-array 32)] (.nextBytes secure-rand b) b)
                 init-ack {:type :init-ack
                           :init-tag (:local-ver-tag @state)

--- a/test/datachannel/sctp_reconnect_test.clj
+++ b/test/datachannel/sctp_reconnect_test.clj
@@ -1,0 +1,70 @@
+(ns datachannel.sctp-reconnect-test
+  (:require [clojure.test :refer :all]
+            [datachannel.core :as core]))
+
+(deftest one-peer-reconnects-test
+  (testing "One Peer Reconnects"
+    (let [out-a (java.util.concurrent.LinkedBlockingQueue.)
+          state-a (atom {:remote-ver-tag 0 :local-ver-tag 1111 :next-tsn 100 :ssn 0 :state :closed})
+          conn-a {:sctp-out out-a :state state-a :on-open (atom nil) :selector nil :on-close (atom nil)}
+
+          out-z (java.util.concurrent.LinkedBlockingQueue.)
+          state-z (atom {:remote-ver-tag 0 :local-ver-tag 2222 :next-tsn 200 :ssn 0 :state :closed})
+          conn-z {:sctp-out out-z :state state-z :on-open (atom nil) :selector nil :on-close (atom nil)}
+
+          handle-sctp-packet #'core/handle-sctp-packet]
+
+      ;; 1. Establish connection between A and Z
+      (reset! state-a (merge @state-a {:state :cookie-wait :init-tag 1111}))
+      (let [init-packet {:src-port 5000 :dst-port 5001 :verification-tag 0
+                         :chunks [{:type :init :init-tag 1111 :a-rwnd 100000
+                                   :outbound-streams 10 :inbound-streams 10
+                                   :initial-tsn 100 :params {}}]}]
+        (handle-sctp-packet init-packet conn-z))
+
+      (let [init-ack (.poll out-z)]
+        (handle-sctp-packet init-ack conn-a))
+
+      (let [cookie-echo (.poll out-a)]
+        (handle-sctp-packet cookie-echo conn-z))
+
+      (let [cookie-ack (.poll out-z)]
+        (handle-sctp-packet cookie-ack conn-a))
+
+      (is (= :established (:state @state-a)) "A should be established")
+      (is (= :established (:state @state-z)) "Z should be established")
+
+      ;; 2. A "reconnects" - starts a new connection attempt from scratch
+      ;; This simulates A crashing or restarting and trying to connect to Z again.
+      (let [out-a2 (java.util.concurrent.LinkedBlockingQueue.)
+            state-a2 (atom {:remote-ver-tag 0 :local-ver-tag 3333 :next-tsn 300 :ssn 0 :state :cookie-wait :init-tag 3333})
+            conn-a2 {:sctp-out out-a2 :state state-a2 :on-open (atom nil) :selector nil :on-close (atom nil)}]
+
+        ;; A2 sends a new INIT to Z
+        (let [init-packet2 {:src-port 5000 :dst-port 5001 :verification-tag 0
+                            :chunks [{:type :init :init-tag 3333 :a-rwnd 100000
+                                      :outbound-streams 10 :inbound-streams 10
+                                      :initial-tsn 300 :params {}}]}]
+          (handle-sctp-packet init-packet2 conn-z))
+
+        ;; Z should reply with INIT-ACK, despite being established
+        (let [init-ack2 (.poll out-z)]
+          (is init-ack2 "Z should reply with INIT-ACK to the new INIT")
+          (is (= :init-ack (-> init-ack2 :chunks first :type)))
+          (handle-sctp-packet (assoc init-ack2 :src-port 5001 :dst-port 5000) conn-a2))
+
+        ;; A2 sends COOKIE-ECHO
+        (let [cookie-echo2 (.poll out-a2)]
+          (is cookie-echo2 "A2 should send COOKIE-ECHO")
+          (is (= :cookie-echo (-> cookie-echo2 :chunks first :type)))
+          (handle-sctp-packet (assoc cookie-echo2 :src-port 5000 :dst-port 5001) conn-z))
+
+        ;; Z should reply with COOKIE-ACK and reset its state
+        (let [cookie-ack2 (.poll out-z)]
+          (is cookie-ack2 "Z should reply with COOKIE-ACK to the new COOKIE-ECHO")
+          (is (= :cookie-ack (-> cookie-ack2 :chunks first :type)))
+          (handle-sctp-packet (assoc cookie-ack2 :src-port 5001 :dst-port 5000) conn-a2))
+
+        (is (= :established (:state @state-a2)) "A2 should be established")
+        (is (= :established (:state @state-z)) "Z should remain established")
+        (is (= 3333 (:remote-ver-tag @state-z)) "Z should have updated its remote verification tag to A2's tag")))))

--- a/test/datachannel/test_runner.clj
+++ b/test/datachannel/test_runner.clj
@@ -18,7 +18,8 @@
             [datachannel.sctp-establish-simultaneous-lost-data-test]
             [datachannel.sctp-unknown-chunk-test]
             [datachannel.sctp-error-chunk-test]
-            [datachannel.sctp-max-message-size-test]))
+            [datachannel.sctp-max-message-size-test]
+            [datachannel.sctp-reconnect-test]))
 
 (defn -main []
   (let [{:keys [fail error]} (test/run-tests 'datachannel.sctp-test
@@ -39,7 +40,8 @@
                                              'datachannel.sctp-establish-simultaneous-lost-data-test
                                              'datachannel.sctp-unknown-chunk-test
                                              'datachannel.sctp-error-chunk-test
-                                             'datachannel.sctp-max-message-size-test)]
+                                             'datachannel.sctp-max-message-size-test
+                                             'datachannel.sctp-reconnect-test)]
     (if (> (+ fail error) 0)
       (System/exit 1)
       (System/exit 0))))


### PR DESCRIPTION
This PR implements the missing "One Peer Reconnects" test case tracking from `TESTING.md`. 

**Changes:**
1. Created `test/datachannel/sctp_reconnect_test.clj` to verify that a previously established connection can re-establish if one peer restarts and sends a new `INIT` chunk.
2. Updated `datachannel.core/handle-sctp-packet` to properly handle `INIT` chunks by resetting the Stream Sequence Number (`:ssn`) to `0` and returning the state to `:cookie-wait`.
3. Updated `test_runner.clj` to register the new test.
4. Marked the test case as complete in `TESTING.md`.

---
*PR created automatically by Jules for task [2149501343521508533](https://jules.google.com/task/2149501343521508533) started by @alpeware*