### PR TITLE
Fix WebRTC datachannel SSN out-of-order drop and add demo server

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -8,6 +8,9 @@
                                dev.onvoid.webrtc/webrtc-java {:mvn/version "0.14.0"}}}
            :lint {:replace-deps {clj-kondo/clj-kondo {:mvn/version "2026.01.19"}
                                  org.clojure/test.check {:mvn/version "1.1.1"}}
-                  :main-opts ["-m" "clj-kondo.main" "--lint" "src" "test"]}
+                  :main-opts ["-m" "clj-kondo.main" "--lint" "src" "test" "dev"]}
            :format {:replace-deps {dev.weavejester/cljfmt {:mvn/version "0.16.1"}}
-                    :main-opts ["-m" "cljfmt.main" "fix" "src" "test"]}}}
+                    :main-opts ["-m" "cljfmt.main" "fix" "src" "test" "dev"]}
+           :example {:extra-paths ["dev"]
+                     :jvm-opts ["--add-exports=java.base/sun.security.tools.keytool=ALL-UNNAMED"
+                                "--add-exports=java.base/sun.security.x509=ALL-UNNAMED"]}}}

--- a/dev/example/index.html
+++ b/dev/example/index.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>datachannel-clj WebRTC Demo</title>
+    <style>
+        body { font-family: system-ui, -apple-system, sans-serif; max-width: 800px; margin: 40px auto; padding: 0 20px; text-align: center; background: #f9f9f9; }
+        h1 { color: #333; }
+        .card { background: white; border-radius: 8px; padding: 20px; box-shadow: 0 4px 6px rgba(0,0,0,0.1); margin-top: 20px; }
+        button { background: #4CAF50; color: white; border: none; padding: 12px 24px; font-size: 16px; border-radius: 4px; cursor: pointer; transition: background 0.2s; }
+        button:hover { background: #45a049; }
+        button:disabled { background: #ccc; cursor: not-allowed; }
+        pre { background: #1e1e1e; color: #00ff00; padding: 15px; border-radius: 4px; overflow-x: auto; text-align: left; font-size: 14px; min-height: 300px; }
+    </style>
+</head>
+<body>
+    <h1>WebRTC Data Channel</h1>
+    <p>This page will connect natively to the Clojure backend via WebRTC UDP DataChannel.</p>
+    
+    <div class="card">
+        <button id="connectBtn">Connect to Server</button>
+        <pre id="logTerminal"></pre>
+    </div>
+
+    <script>
+        const serverSdp = `SERVER_SDP_PLACEHOLDER`;
+        const logTerminal = document.getElementById('logTerminal');
+        const connectBtn = document.getElementById('connectBtn');
+
+        function log(msg) {
+            logTerminal.textContent += `[${new Date().toISOString().split('T')[1].split('.')[0]}] ${msg}\n`;
+            logTerminal.scrollTop = logTerminal.scrollHeight;
+        }
+
+        connectBtn.onclick = async () => {
+            connectBtn.disabled = true;
+            log("Initializing RTCPeerConnection...");
+            
+            const pc = new RTCPeerConnection({
+                iceServers: [] // Local connection doesn't need external STUN
+            });
+
+            // The datachannel-clj implementation does not perform in-band negotiation
+            // for the default channel, so we set negotiated: true to match its behavior.
+            log("Creating new DataChannel (id: 0, negotiated: true)...");
+            const dc = pc.createDataChannel("test-channel");
+
+            let pingInterval;
+
+            dc.onmessage = (e) => {
+                log("<< Received message! e.data = " + e.data + " (Type: " + typeof(e.data) + ")");
+                console.log("Recv msg:", e);
+            };
+
+            dc.onclose = () => { log("🔴 Data channel closed."); clearInterval(pingInterval); connectBtn.disabled = false; };
+            dc.onerror = (e) => { log("⚠️ Data channel error: " + e); console.error("DC error", e); };
+            dc.onopen = () => {
+                log("🟢 DataChannel IS OPEN!");
+                const msg = "Hello from the Browser JS!";
+                log(">> Sending: " + msg);
+                dc.send(msg);
+                
+                let counter = 1;
+                pingInterval = setInterval(() => {
+                    const text = `Ping ${counter++}`;
+                    log(">> Sending: " + text);
+                    dc.send(text);
+                }, 3000);
+            };
+            
+            pc.oniceconnectionstatechange = () => { log("🧊 ICE Connection State: " + pc.iceConnectionState); };
+            pc.onconnectionstatechange = () => { log("🔌 Peer Connection State: " + pc.connectionState); };
+
+            try {
+                // Client creates an exact offer (so it binds its own ports)
+                const offer = await pc.createOffer();
+                await pc.setLocalDescription(offer);
+                log("Successfully created and set Local Offer.");
+
+                log("Setting Remote Description (Server's static SDP)...");
+                await pc.setRemoteDescription({
+                    type: 'answer',
+                    sdp: serverSdp
+                });
+                log("Remote Description applied! Handshake started.");
+            } catch (err) {
+                log("❌ Error during WebRTC negotiation: " + err);
+                connectBtn.disabled = false;
+            }
+        };
+    </script>
+</body>
+</html>

--- a/dev/example/server.clj
+++ b/dev/example/server.clj
@@ -1,0 +1,94 @@
+(ns example.server
+  (:require [datachannel.api :as api]
+            [datachannel.dtls :as dtls]
+            [datachannel.sdp :as sdp])
+  (:import [com.sun.net.httpserver HttpServer HttpHandler HttpExchange]
+           [java.net InetSocketAddress]))
+
+(defn -main
+  "Main entry point for the example WebRTC server."
+  [& _args]
+  (println "Starting example WebRTC datachannel server...")
+
+  (let [port 5005
+        http-port 8085
+        ice-creds (sdp/generate-ice-credentials)
+        cert-data (dtls/generate-cert)
+
+        ;; Start the WebRTC UDP listener
+        _listener-node
+        (api/listen! {:port port
+                      :ice-creds ice-creds
+                      :cert-data cert-data}
+                     {:on-connection
+                      (fn [node]
+                        (println "\n[WebRTC] New incoming connection attempt!")
+                        (api/set-callbacks! node
+                                            {:on-open
+                                             (fn [_]
+                                               (println "[WebRTC] Data channel opened!"))
+
+                                             :on-message
+                                             (fn [msg]
+                                               (let [payload (if (:is-string? msg)
+                                                               (String. ^bytes (:payload msg) "UTF-8")
+                                                               (String. ^bytes (:payload msg) "UTF-8"))
+                                                     channel-id (:stream-id msg)
+                                                     protocol (:protocol msg)]
+                                                 (println "[WebRTC] Received chunk:" payload "on stream" channel-id "protocol" protocol)
+                                                 (let [reply (str "Pong: " payload)]
+                                                   (println "[WebRTC] Sending reply:" reply)
+                                                   (api/send! node reply channel-id))))
+
+                                             :on-error
+                                             (fn [err]
+                                               (println "[WebRTC] Error:" err))
+
+                                             :on-close
+                                             (fn [_]
+                                               (println "[WebRTC] Connection closed."))}))})
+
+        ;; Generate the Server's SDP to be offered as Answer to the JS client
+        base-sdp (sdp/format-answer {:local-ip "127.0.0.1"
+                                     :port port
+                                     :ice-ufrag (:ufrag ice-creds)
+                                     :ice-pwd (:pwd ice-creds)
+                                     :fingerprint (:fingerprint cert-data)
+                                     :setup "passive"
+                                     :ice-lite? true})
+        server-sdp (str base-sdp "a=candidate:1 1 UDP 2130706431 127.0.0.1 " port " typ host\r\n")
+
+        ;; Start the HTTP server to serve the client JS
+        http-server (HttpServer/create (InetSocketAddress. http-port) 0)]
+
+    (.createContext http-server "/"
+                    (proxy [HttpHandler] []
+                      (handle [^HttpExchange exchange]
+                        (try
+                          (let [method (.getRequestMethod exchange)]
+                            (if (= method "GET")
+                              (let [html (slurp "dev/example/index.html")
+                                    ;; Inject the server's static SDP into the HTML template
+                                    response (.replace html "SERVER_SDP_PLACEHOLDER" server-sdp)
+                                    bytes (.getBytes response "UTF-8")]
+                                (.sendResponseHeaders exchange 200 (alength bytes))
+                                (with-open [os (.getResponseBody exchange)]
+                                  (.write os bytes)))
+                              (do
+                                (.sendResponseHeaders exchange 405 -1)
+                                (.close exchange))))
+                          (catch Exception e
+                            (println "HTTP Error:" (.getMessage e))
+                            (.sendResponseHeaders exchange 500 -1)
+                            (.close exchange))))))
+
+    (.setExecutor http-server nil)
+    (.start http-server)
+
+    (println (str "\nServer started!\n"
+                  "1. WebRTC listener listening on UDP port " port "\n"
+                  "2. HTTP server running. Open http://localhost:" http-port " in your browser.\n\n"
+                  "Waiting for connections..."))
+
+    ;; Keep the main thread alive
+    @(promise)))

--- a/src/datachannel/api.clj
+++ b/src/datachannel/api.clj
@@ -364,6 +364,7 @@
                                  @(:callbacks child-node)))))))
         (catch Exception e
           (println "Error in api listen loop:" (.getMessage e))
+          (.printStackTrace e)
           (when-let [cb (:on-error listener-callbacks)]
             (cb {:type :on-error :cause e})))))))
 

--- a/src/datachannel/core.clj
+++ b/src/datachannel/core.clj
@@ -89,8 +89,9 @@
 
 (defn serialize-network-out
   "Encodes items in :network-out into ByteBuffers and stores them in :network-out-bytes"
-  [result-map & [^ByteBuffer opt-buf]]
-  (let [zero-checksum? (get-in result-map [:new-state :metrics :uses-zero-checksum])
+  [result-map & opt-args]
+  (let [opt-buf (first opt-args)
+        zero-checksum? (get-in result-map [:new-state :metrics :uses-zero-checksum])
         engine (get-in result-map [:new-state :dtls/engine])
         encoded (mapv (fn [item]
                         (cond
@@ -344,7 +345,7 @@
     (let [_ver-tag (:remote-ver-tag state)
           channel-opts (get-in state [:data-channels stream-id])
           ordered? (if (some? channel-opts) (:ordered channel-opts) true)
-          ssn (if ordered? (get-in state [:streams stream-id :next-ssn] 0) 0)
+          ssn (if ordered? (get-in state [:streams stream-id :next-tx-ssn] 0) 0)
           mtu (get state :mtu 1200)
           max-payload-per-chunk (- mtu 16)
           is-established? (= (:state state) :established)
@@ -366,7 +367,7 @@
                    (if (empty? remaining-frags)
                      (let [s1 (-> current-state
                                   (assoc :next-tsn current-tsn)
-                                  (cond-> ordered? (assoc-in [:streams stream-id :next-ssn] (inc ssn))))
+                                  (cond-> ordered? (assoc-in [:streams stream-id :next-tx-ssn] (inc ssn))))
                            interval (get s1 :heartbeat-interval 30000)
                            s2 (if (and (pos? interval) (contains? (:timers s1) :sctp/t-heartbeat))
                                 (assoc-in s1 [:timers :sctp/t-heartbeat] {:expires-at (+ now-ms interval)})

--- a/src/datachannel/handlers.clj
+++ b/src/datachannel/handlers.clj
@@ -175,7 +175,7 @@
   (let [interval (get state :heartbeat-interval 30000)
         rto (get state :rto-initial 1000)
         hb-chunk {:type :heartbeat
-                  :params [{:type :heartbeat-info :info (byte-array 8)}]}]
+                  :params {:heartbeat (byte-array 8)}}]
     {:new-state (-> state
                     (assoc-in [:timers :sctp/t-heartbeat] {:expires-at (+ now-ms interval)})
                     (assoc-in [:timers :sctp/t-heartbeat-rtx] {:expires-at (+ now-ms rto)})


### PR DESCRIPTION
- Resolves an SSN bleeding bug in datachannel/core.clj where outbound transmission (Tx) sequence numbers incorrectly read from the inbound (Rx) sequence pointer. This caused dc.onmessage handlers in strict WebRTC implementations to drop messages.

- Adds an interactive WebRTC datachannel example relying on DCEP negotiation.

- Fixes handlers.clj heartbeat chunk parameter destructuring.

- Adds :example alias to deps.edn.